### PR TITLE
Fix Documentation to Include Working Mac Java8 Installation Instructions

### DIFF
--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -6,7 +6,7 @@ Welcome to MineRL! This guide will get you started.
 
 
 To start using the data and set of reinforcement learning
-enviroments comprising MineRL, you'll need to install the
+environments comprising MineRL, you'll need to install the
 main python package, :code:`minerl`.
 
 .. _OpenJDK 8: https://openjdk.java.net/install/
@@ -21,14 +21,14 @@ main python package, :code:`minerl`.
    b. On Mac, you can install java8 using homebrew and AdoptOpenJDK (an open source mirror, used here to get around the fact that Java8 binaries are
    no longer available directly from Oracle)::
 
-        brew tap AdoptOpenJDK/openjdk
-        brew cask install adoptopenjdk8
+      brew tap AdoptOpenJDK/openjdk
+      brew cask install adoptopenjdk8
 
    c. On Debian based systems (Ubuntu!) you can run the following::
 
-        sudo add-apt-repository ppa:openjdk-r/ppa
-        sudo apt-get update
-        sudo apt-get install openjdk-8-jdk
+      sudo add-apt-repository ppa:openjdk-r/ppa
+      sudo apt-get update
+      sudo apt-get install openjdk-8-jdk
 
 2. Now install the :code:`minerl` package!::
 

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -33,6 +33,15 @@ main python package, :code:`minerl`.
 
         pip3 install --upgrade minerl
 
+.. note::
+        depending on your system you may need the user flag:
+        :code:`pip3 install --upgrade minerl --user` to install property
+
+3. (Optional) Download the dataset - 13.6 GB::
+
+        import minerl
+        minerl.data.download(data_dir="/your/local/path/")
+
 **That's it! Now you're good to go :) 💯💯💯**
 
 .. caution:: 

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -18,7 +18,7 @@ main python package, :code:`minerl`.
    a. `Windows installer`_  -- On windows go this link and follow the
       instructions to install JDK 8.
 
-   b. On mac, with homebrew installed you can use the following::
+   b. On Mac, you can install java8 using homebrew and AdoptOpenJDK (an open source mirror, used here to get around the fact that Java8 binaries are no longer available directly from Oracle)::
 
         brew tap caskroom/versions
         brew cask install java8

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -6,7 +6,7 @@ Welcome to MineRL! This guide will get you started.
 
 
 To start using the data and set of reinforcement learning
-enviroments comrpising MineRL, you'll need to install the
+enviroments comprising MineRL, you'll need to install the
 main python package, :code:`minerl`.
 
 .. _OpenJDK 8: https://openjdk.java.net/install/
@@ -18,10 +18,11 @@ main python package, :code:`minerl`.
    a. `Windows installer`_  -- On windows go this link and follow the
       instructions to install JDK 8.
 
-   b. On mac, with homebrew installed you can use the following::
+   b. On Mac, you can install java8 using homebrew and AdoptOpenJDK (an open source mirror, used here to get around the fact that Java8 binaries are
+   no longer available directly from Oracle):
 
-        brew tap caskroom/versions
-        brew cask install java8  
+        brew tap AdoptOpenJDK/openjdk
+        brew cask install adoptopenjdk8
 
    c. On Debian based systems (Ubuntu!) you can run the following::
 
@@ -44,9 +45,9 @@ main python package, :code:`minerl`.
 
 **That's it! Now you're good to go :) 💯💯💯**
 
-.. caution:: 
+.. caution::
     Currently :code:`minerl` only supports environment rendering in **headed environments**
-    (machines with monitors attached). 
+    (machines with monitors attached).
 
 
     **In order to run** :code:`minerl` **environments without a head use a software renderer

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -20,8 +20,8 @@ main python package, :code:`minerl`.
 
    b. On Mac, you can install java8 using homebrew and AdoptOpenJDK (an open source mirror, used here to get around the fact that Java8 binaries are no longer available directly from Oracle)::
 
-        brew tap caskroom/versions
-        brew cask install java8
+        brew tap AdoptOpenJDK/openjdk
+        brew cask install adoptopenjdk8
 
    c. On Debian based systems (Ubuntu!) you can run the following::
 

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -46,7 +46,7 @@ main python package, :code:`minerl`.
 
 .. caution::
     Currently :code:`minerl` only supports environment rendering in **headed environments**
-    (machines with monitors attached).
+    (machines with monitors attached). 
 
 
     **In order to run** :code:`minerl` **environments without a head use a software renderer

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -6,7 +6,7 @@ Welcome to MineRL! This guide will get you started.
 
 
 To start using the data and set of reinforcement learning
-enviroments comrpising MineRL, you'll need to install the
+environments comprising MineRL, you'll need to install the
 main python package, :code:`minerl`.
 
 .. _OpenJDK 8: https://openjdk.java.net/install/

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -6,7 +6,7 @@ Welcome to MineRL! This guide will get you started.
 
 
 To start using the data and set of reinforcement learning
-environments comprising MineRL, you'll need to install the
+enviroments comrpising MineRL, you'll need to install the
 main python package, :code:`minerl`.
 
 .. _OpenJDK 8: https://openjdk.java.net/install/
@@ -18,17 +18,16 @@ main python package, :code:`minerl`.
    a. `Windows installer`_  -- On windows go this link and follow the
       instructions to install JDK 8.
 
-   b. On Mac, you can install java8 using homebrew and AdoptOpenJDK (an open source mirror, used here to get around the fact that Java8 binaries are
-   no longer available directly from Oracle)::
+   b. On mac, with homebrew installed you can use the following::
 
-      brew tap AdoptOpenJDK/openjdk
-      brew cask install adoptopenjdk8
+        brew tap caskroom/versions
+        brew cask install java8
 
    c. On Debian based systems (Ubuntu!) you can run the following::
 
-      sudo add-apt-repository ppa:openjdk-r/ppa
-      sudo apt-get update
-      sudo apt-get install openjdk-8-jdk
+        sudo add-apt-repository ppa:openjdk-r/ppa
+        sudo apt-get update
+        sudo apt-get install openjdk-8-jdk
 
 2. Now install the :code:`minerl` package!::
 

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -19,7 +19,7 @@ main python package, :code:`minerl`.
       instructions to install JDK 8.
 
    b. On Mac, you can install java8 using homebrew and AdoptOpenJDK (an open source mirror, used here to get around the fact that Java8 binaries are
-   no longer available directly from Oracle):
+   no longer available directly from Oracle)::
 
         brew tap AdoptOpenJDK/openjdk
         brew cask install adoptopenjdk8

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -46,7 +46,7 @@ main python package, :code:`minerl`.
 
 .. caution:: 
     Currently :code:`minerl` only supports environment rendering in **headed environments**
-    (servers with monitors attached). 
+    (machines with monitors attached). 
 
 
     **In order to run** :code:`minerl` **environments without a head use a software renderer


### PR DESCRIPTION
Per #30 , this PR contains modifications of the docs to use AdoptOpenJDK brew cask to install Java8, to deal with the fact that Oracle has deprecated the original links for the java8 binaries used in the old instructions. Also includes a few small spelling fixes. 