### PR TITLE
Added flatworld envs (dense)

### DIFF
--- a/minerl/env/__init__.py
+++ b/minerl/env/__init__.py
@@ -1,15 +1,15 @@
 # ------------------------------------------------------------------------------------------------
 # Copyright (c) 2018 Microsoft Corporation
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 # associated documentation files (the "Software"), to deal in the Software without restriction,
 # including without limitation the rights to use, copy, modify, merge, publish, distribute,
 # sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all copies or
 # substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
 # NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -27,7 +27,7 @@ from minerl.env.core import MineRLEnv, missions_dir
 
 import numpy as np
 
-  
+
 register(
     id='MineRLTreechop-v0',
     entry_point='minerl.env:MineRLEnv',
@@ -37,32 +37,32 @@ register(
             'pov': spaces.Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
         }),
         'action_space': spaces.Dict(spaces={
-            "forward": spaces.Discrete(2), 
-            "back": spaces.Discrete(2), 
-            "left": spaces.Discrete(2), 
-            "right": spaces.Discrete(2), 
-            "jump": spaces.Discrete(2), 
-            "sneak": spaces.Discrete(2), 
-            "sprint": spaces.Discrete(2), 
+            "forward": spaces.Discrete(2),
+            "back": spaces.Discrete(2),
+            "left": spaces.Discrete(2),
+            "right": spaces.Discrete(2),
+            "jump": spaces.Discrete(2),
+            "sneak": spaces.Discrete(2),
+            "sprint": spaces.Discrete(2),
             "attack": spaces.Discrete(2),
             "camera": spaces.Box(low=-180, high=180, shape=(2,), dtype=np.float32),
         }),
         'docstr': """
 .. image:: ../assets/treechop1.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/treechop2.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/treechop3.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/treechop4.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 In treechop, the agent must collect 64 `minercaft:log`. This replicates a common scenario in Minecraft, as logs are necessary to craft a large amount of items in the game, and are a key resource in Minecraft.
 
 The agent begins in a forest biome (near many trees) with an iron axe for cutting trees. The agent is given +1 reward for obtaining each unit of wood, and the episode terminates once the agent obtains 64 units.\n"""
@@ -80,26 +80,26 @@ def make_navigate_text(top, dense):
     navigate_text = """
 .. image:: ../assets/navigate{}1.mp4.gif
     :scale: 100 %
-    :alt: 
+    :alt:
 
 .. image:: ../assets/navigate{}2.mp4.gif
     :scale: 100 %
-    :alt: 
+    :alt:
 
 .. image:: ../assets/navigate{}3.mp4.gif
     :scale: 100 %
-    :alt: 
+    :alt:
 
 .. image:: ../assets/navigate{}4.mp4.gif
     :scale: 100 %
-    :alt: 
+    :alt:
 
 In this task, the agent must move to a goal location denoted by a diamond block. This represents a basic primitive used in many tasks throughout Minecraft. In addition to standard observations, the agent has access to a “compass” observation, which points near the goal location, 64 meters from the start location. The goal has a small random horizontal offset from the compass location and may be slightly below surface level. On the goal location is a unique block, so the agent must find the final goal by searching based on local visual features.
 
 The agent is given a sparse reward (+100 upon reaching the goal, at which point the episode terminates). """
     if dense:
         navigate_text += "**This variant of the environment is dense reward-shaped where the agent is given a reward every tick for how much closer (or negative reward for farther) the agent gets to the target.**\n"
-    else: 
+    else:
         navigate_text += "**This variant of the environment is sparse.**\n"
 
     if top is "normal":
@@ -157,13 +157,38 @@ register(
 
 
 register(
+    id='MineRLNavigateDenseFlatDeterministic-v0',
+    entry_point='minerl.env:MineRLEnv',
+    kwargs={
+        'xml': os.path.join(missions_dir, 'navigationDenseFlatDeterministic.xml'),
+        'observation_space': navigate_observation_space,
+        'action_space': navigate_action_space,
+        'docstr': make_navigate_text('normal', True)
+    },
+    max_episode_steps=2000,
+)
+
+register(
+    id='MineRLNavigateDenseFlat-v0',
+    entry_point='minerl.env:MineRLEnv',
+    kwargs={
+        'xml': os.path.join(missions_dir, 'navigationDenseFlat.xml'),
+        'observation_space': navigate_observation_space,
+        'action_space': navigate_action_space,
+        'docstr': make_navigate_text('normal', True)
+    },
+    max_episode_steps=2000,
+)
+
+
+register(
     id='MineRLNavigateExtreme-v0',
     entry_point='minerl.env:MineRLEnv',
     kwargs={
         'xml': os.path.join(missions_dir, 'navigationExtreme.xml'),
         'observation_space': navigate_observation_space,
         'action_space': navigate_action_space,
-        'docstr': make_navigate_text('extreme', False) 
+        'docstr': make_navigate_text('extreme', False)
     },
     max_episode_steps=6000,
 )
@@ -175,7 +200,7 @@ register(
         'xml': os.path.join(missions_dir, 'navigationExtremeDense.xml'),
         'observation_space': navigate_observation_space,
         'action_space': navigate_action_space,
-        'docstr': make_navigate_text('extreme', True)  
+        'docstr': make_navigate_text('extreme', True)
     },
     max_episode_steps=6000,
 )
@@ -244,19 +269,19 @@ register(
         'docstr': """
 .. image:: ../assets/orion1.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/orion2.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/orion3.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/orion4.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 In this environment the agent is required to obtain an iron pickaxe. The agent begins in a random starting location, on a random survival map, without any items, matching the normal starting conditions for human players in Minecraft.
 The agent is given access to a selected view of its inventory and GUI free
 crafting, smelting, and inventory management actions.
@@ -293,19 +318,19 @@ register(
         'docstr': """
 .. image:: ../assets/orion1.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/orion2.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/orion3.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/orion4.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 In this environment the agent is required to obtain an iron pickaxe. The agent begins in a random starting location, on a random survival map, without any items, matching the normal starting conditions for human players in Minecraft.
 The agent is given access to a selected view of its inventory and GUI free
 crafting, smelting, and inventory management actions.
@@ -345,19 +370,19 @@ register(
         'docstr': """
 .. image:: ../assets/odia1.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/odia2.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/odia3.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/odia4.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. caution::
     **This is the evaluation environment of the MineRL Competition!** Specifically, you are allowed
@@ -402,19 +427,19 @@ register(
         'docstr': """
 .. image:: ../assets/odia1.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/odia2.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/odia3.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 .. image:: ../assets/odia4.mp4.gif
   :scale: 100 %
-  :alt: 
+  :alt:
 
 In this environment the agent is required to obtain a diamond. The agent begins in a random starting location on a random survival map without any items, matching the normal starting conditions for human players in Minecraft.
 The agent is given access to a selected summary of its inventory and GUI free

--- a/minerl/env/missions/navigationDenseFlat.xml
+++ b/minerl/env/missions/navigationDenseFlat.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Mission xmlns="http://ProjectMalmo.microsoft.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <About>
+        <Summary>$(ENV_NAME)</Summary>
+    </About>
+
+    <ModSettings>
+        <MsPerTick>50</MsPerTick>
+    </ModSettings>
+
+    <ServerSection>
+        <ServerInitialConditions>
+            <Time>
+                <StartTime>6000</StartTime>
+                <AllowPassageOfTime>false</AllowPassageOfTime>
+            </Time>
+            <Weather>clear</Weather>
+            <AllowSpawning>false</AllowSpawning>
+        </ServerInitialConditions>
+        <ServerHandlers>
+            <FlatWorldGenerator forceReset="true"/>
+            <NavigationDecorator>
+                <randomPlacementProperties>
+                    <maxRandomizedRadius>64</maxRandomizedRadius>
+                    <minRandomizedRadius>64</minRandomizedRadius>
+                    <maxRadius>8</maxRadius>
+                    <minRadius>0</minRadius>
+                    <block>diamond_block</block>
+                    <placement>surface</placement>
+                </randomPlacementProperties>
+                <minRandomizedDistance>0</minRandomizedDistance>
+                <maxRandomizedDistance>8</maxRandomizedDistance>
+                <randomizeCompassLocation>true</randomizeCompassLocation>
+            </NavigationDecorator>
+            <ServerQuitFromTimeUp timeLimitMs="300000" description="out_of_time"/>
+            <ServerQuitWhenAnyAgentFinishes/>
+        </ServerHandlers>
+    </ServerSection>
+
+    <AgentSection mode="Survival">
+        <Name>MineRLAgent</Name>
+        <AgentStart>
+            <Inventory>
+                    <InventoryObject slot="0" type="compass" quantity="1"/>
+            </Inventory>
+        </AgentStart>
+        <AgentHandlers>
+            <VideoProducer want_depth="false">
+                <Width>64</Width>
+                <Height>64</Height>
+            </VideoProducer>
+            <FileBasedPerformanceProducer/>
+
+            <ObservationFromFullInventory flat="false"/>
+            <ObservationFromFullStats/>
+            <HumanLevelCommands>
+                <ModifierList type="deny-list">
+                <command>moveMouse</command>
+                <command>inventory</command>
+                </ModifierList>
+            </HumanLevelCommands>
+            <CameraCommands/>
+            <ObservationFromCompass/>
+
+            <RewardForMissionEnd>
+                <Reward description="out_of_time" reward="0" />
+            </RewardForMissionEnd>
+            <AgentQuitFromTouchingBlockType>
+                <Block type="diamond_block"/>
+            </AgentQuitFromTouchingBlockType>
+            <RewardForTouchingBlockType>
+                <Block reward="100.0" type="diamond_block" behaviour="onceOnly"/>
+            </RewardForTouchingBlockType>
+            <RewardForDistanceTraveledToCompassTarget rewardPerBlock="1" density="PER_TICK"/>
+            <PauseCommand/>
+        </AgentHandlers>
+    </AgentSection>
+</Mission>

--- a/minerl/env/missions/navigationDenseFlatDeterministic.xml
+++ b/minerl/env/missions/navigationDenseFlatDeterministic.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Mission xmlns="http://ProjectMalmo.microsoft.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <About>
+        <Summary>$(ENV_NAME)</Summary>
+    </About>
+
+    <ModSettings>
+        <MsPerTick>50</MsPerTick>
+    </ModSettings>
+
+    <ServerSection>
+        <ServerInitialConditions>
+            <Time>
+                <StartTime>6000</StartTime>
+                <AllowPassageOfTime>false</AllowPassageOfTime>
+            </Time>
+            <Weather>clear</Weather>
+            <AllowSpawning>false</AllowSpawning>
+        </ServerInitialConditions>
+        <ServerHandlers>
+            <FlatWorldGenerator forceReset="true"/>
+            <NavigationDecorator>
+                <randomPlacementProperties>
+                    <maxRandomizedRadius>64</maxRandomizedRadius>
+                    <minRandomizedRadius>64</minRandomizedRadius>
+                    <maxRadius>8</maxRadius>
+                    <minRadius>0</minRadius>
+                    <block>diamond_block</block>
+                    <placement>surface</placement>
+                </randomPlacementProperties>
+                <minRandomizedDistance>0</minRandomizedDistance>
+                <maxRandomizedDistance>8</maxRandomizedDistance>
+                <randomizeCompassLocation>false</randomizeCompassLocation>
+            </NavigationDecorator>
+            <ServerQuitFromTimeUp timeLimitMs="300000" description="out_of_time"/>
+            <ServerQuitWhenAnyAgentFinishes/>
+        </ServerHandlers>
+    </ServerSection>
+
+    <AgentSection mode="Survival">
+        <Name>MineRLAgent</Name>
+        <AgentStart>
+            <Inventory>
+                    <InventoryObject slot="0" type="compass" quantity="1"/>
+            </Inventory>
+        </AgentStart>
+        <AgentHandlers>
+            <VideoProducer want_depth="false">
+                <Width>64</Width>
+                <Height>64</Height>
+            </VideoProducer>
+            <FileBasedPerformanceProducer/>
+
+            <ObservationFromFullInventory flat="false"/>
+            <ObservationFromFullStats/>
+            <HumanLevelCommands>
+                <ModifierList type="deny-list">
+                <command>moveMouse</command>
+                <command>inventory</command>
+                </ModifierList>
+            </HumanLevelCommands>
+            <CameraCommands/>
+            <ObservationFromCompass/>
+
+            <RewardForMissionEnd>
+                <Reward description="out_of_time" reward="0" />
+            </RewardForMissionEnd>
+            <AgentQuitFromTouchingBlockType>
+                <Block type="diamond_block"/>
+            </AgentQuitFromTouchingBlockType>
+            <RewardForTouchingBlockType>
+                <Block reward="100.0" type="diamond_block" behaviour="onceOnly"/>
+            </RewardForTouchingBlockType>
+            <RewardForDistanceTraveledToCompassTarget rewardPerBlock="1" density="PER_TICK"/>
+            <PauseCommand/>
+        </AgentHandlers>
+    </AgentSection>
+</Mission>


### PR DESCRIPTION
Adding to environments:
- **MineRLNavigateDenseFlat-v0**: flat world, dense rewards and goal around the compass targat at distance 8
- **MineRLNavigateDenseFlatDeterministic-v0**: flat world, dense rewards, goal is exactly pointed by the compass. Used for testing and solvable using just the compass angle.

Could be extended also in the sparse setting for testing.