### PR TITLE
[fix] document (first_agent.rst)

### DIFF
--- a/docs/source/tutorials/first_agent.rst
+++ b/docs/source/tutorials/first_agent.rst
@@ -156,7 +156,7 @@ the angle between the agent's movement direction and it's target,  :code:`compas
     env = gym.make('MineRLNavigateDense-v0') 
     
     
-    obs  = env.reset() 
+    obs, _ = env.reset() 
     done = False 
     net_reward = 0
     


### PR DESCRIPTION
I found 'obs' has unexpected data type.

```
({'compassAngle': -19.421326, 'inventory': {'dirt': 0}, 'pov': array([[[ 47,  47,  47],
        [ 67,  67,  67],
        [ 69,  69,  69],
        ...,
        [ 20,  31,  20],
        [ 18,  29,  18],
        [ 18,  29,  18]],

       [[ 76,  76,  76],
        [ 81,  81,  81],
        [ 82,  82,  82],
        ...,
        [ 19,  30,  19],
        [ 18,  29,  18],
        [ 17,  27,  17]],

       [[ 85,  85,  85],
        [ 90,  90,  90],
        [ 88,  88,  88],
        ...,
        [ 17,  28,  17],
        [ 17,  26,  17],
        [ 18,  29,  18]],

       ...,

       [[ 75, 103,  73],
        [ 73, 100,  71],
        [ 76, 104,  74],
        ...,
        [100, 136,  98],
        [ 61,  84,  60],
        [ 61,  84,  60]],

       [[ 72,  99,  70],
        [ 76, 105,  74],
        [ 77, 105,  75],
        ...,
        [100, 136,  98],
        [100, 136,  98],
        [ 61,  84,  60]],

       [[ 67,  92,  65],
        [ 67,  92,  65],
        [ 72,  98,  70],
        ...,
        [100, 136,  98],
        [100, 136,  98],
        [100, 136,  98]]], dtype=uint8)}, {})
```