### PR TITLE
add dill requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ Pyro4>=4.76
 getch>=1.0; sys_platform != 'win32' and sys_platform != 'cygwin'
 coloredlogs>=10.0
 matplotlib==3.0.3
+dill>=0.3.1.1


### PR DESCRIPTION
To fix the following error from `import minerl` :

```
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-3e124afb758f> in <module>
----> 1 import minerl

~/Projects/pfn/minerl2019/minerl/minerl/__init__.py in <module>
      3 import minerl.data
      4 import minerl.env
----> 5 import minerl.herobraine.envs

~/Projects/pfn/minerl2019/minerl/minerl/herobraine/envs.py in <module>
      7 from minerl.herobraine.env_specs.navigate_specs import Navigate
      8 from minerl.herobraine.env_specs.obtain_specs import ObtainDiamond, ObtainDiamondSurvival, ObtainIronPickaxe, Obtain, ObtainDiamondDebug
----> 9 from minerl.herobraine.wrappers import Obfuscated, Vectorized
     10 import os
     11

~/Projects/pfn/minerl2019/minerl/minerl/herobraine/wrappers/__init__.py in <module>
----> 1 from minerl.herobraine.wrappers.obfuscation_wrapper import Obfuscated
      2 from minerl.herobraine.wrappers.vector_wrapper import Vectorized

~/Projects/pfn/minerl2019/minerl/minerl/herobraine/wrappers/obfuscation_wrapper.py in <module>
      9 from minerl.herobraine.wrapper import EnvWrapper
     10 import copy
---> 11 import dill
     12 import os
     13

ModuleNotFoundError: No module named 'dill'
```