### PR TITLE
Randomized port allocation with retry

### DIFF
--- a/minerl/env/core.py
+++ b/minerl/env/core.py
@@ -714,7 +714,7 @@ class MineRLEnv(gym.Env):
                                  "have to do so manually later.")
                     raise RuntimeError("Port is unusable")
                 else:
-                    logger.error("Did not get an OK from Malmo; trying again.")
+                    logger.debug("Recieved a MALMOBUSY from Malmo; trying again.")
                     time.sleep(1)
 
     def _get_token(self):
@@ -735,7 +735,6 @@ class MineRLEnv(gym.Env):
             return
 
         log_file = os.path.join(self.instance.minecraft_dir, 'run', 'logs', 'latest.log')
-        print(log_file)
         return tail(log_file, lines=num_lines)
 
 

--- a/minerl/env/malmo.py
+++ b/minerl/env/malmo.py
@@ -27,7 +27,6 @@ import pathlib
 import Pyro4.core
 import argparse
 from enum import Enum
-
 import random
 import shutil
 import socket


### PR DESCRIPTION
Fixes a race condition where MineRLEnv fails to launch if multiple MineRLEnv are launched in parallel from different process (e.g. 5 different seeds of the same training script).

On my machine, using this branch, when I launch 5 MineRLEnv in parallel,
there is still a ~20% chance of MineRLEnv failing due to race condition
that reports corrupted Gradle pack error. (Fixed later by HumanCompatibleAI/pull/6).

## Original PR description from HumanCompatibleAI/pull/5:

We run into a race condition when multiple processes launch MineRL environments from different InstanceManagers, and different Minecraft instances are instructed to bind to the same port.

While connecting to Minecraft, MineRLEnv now looks for `BindException` inside the Minecraft process's logs (indicating a port collision) and immediately relaunch a new Minecraft instance with a different port when this happens. This allows us to recover from the race condition, but is expensive because launching a Minecraft instance takes time.

The InstanceManager port allocation scheme now chooses randomly from unbound ephemeral ports instead of linearly searching through (9000, 9001, ...). This reduces the chance of a race condition arising.

Other changes:
* Removed `InstanceManager._malmo_base_port`. This used to be used primarily as a starting point for linearly searching for available ports. Since we randomly allocate now this isn't necessary.
* Removed `InstanceManager.is_display_port()`, as it always returned False and depended on `InstanceManager._malmo_base_port`.