### PR TITLE
Don't try to download missing files

### DIFF
--- a/minerl/data/download.py
+++ b/minerl/data/download.py
@@ -79,7 +79,7 @@ def download(directory=None, resolution='low', texture_pack=0, update_environmen
     mirrors = [
         "https://minerl.s3.amazonaws.com/",
         "https://minerl-asia.s3.amazonaws.com/",
-        "https://minerl-europe.s3.amazonaws.com/"]  # , "https://router2.sneakywines.me/"]
+        "https://minerl-europe.s3.amazonaws.com/"]
 
     if experiment is None:
         min_str = '_minimal' if minimal else ''
@@ -91,7 +91,7 @@ def download(directory=None, resolution='low', texture_pack=0, update_environmen
         if os.path.exists(os.path.join(directory, experiment)):
             logger.warning("{} exists - skipping re-download!".format(os.path.join(directory, experiment)))
             return directory
-        filename = "minerl/v{}/{}.tar".format(DATA_VERSION, experiment)
+        filename = "v{}/{}.tar".format(DATA_VERSION, experiment)
         urls = [mirror + filename for mirror in mirrors]
     try:
         logger.info("Fetching download hash ...")
@@ -102,7 +102,7 @@ def download(directory=None, resolution='low', texture_pack=0, update_environmen
         dest_file = os.path.join(download_path, filename)
         os.makedirs(os.path.dirname(dest_file), exist_ok=True)
         download_with_resume(urls, dest_file)
-    except HTTPError as e:
+        except HTTPError as e:
         logger.error("HTTP error encountered when downloading")
         if experiment is not None:
             logger.error("is {}  a valid minerl environment?".format(experiment))

--- a/minerl/data/download.py
+++ b/minerl/data/download.py
@@ -23,8 +23,6 @@ import coloredlogs
 logger = logging.getLogger(__name__)
 
 
-      
-
 def download(directory=None, resolution='low', texture_pack=0, update_environment_variables=True, disable_cache=False,
              experiment=None, minimal=False):
     """Downloads MineRLv0 to specified directory. If directory is None, attempts to 
@@ -102,11 +100,10 @@ def download(directory=None, resolution='low', texture_pack=0, update_environmen
         dest_file = os.path.join(download_path, filename)
         os.makedirs(os.path.dirname(dest_file), exist_ok=True)
         download_with_resume(urls, dest_file)
-        except HTTPError as e:
-        logger.error("HTTP error encountered when downloading")
+    except HTTPError as e:
+        logger.error("HTTP {} error encountered when downloading files!".format(e.code))
         if experiment is not None:
-            logger.error("is {}  a valid minerl environment?".format(experiment))
-        logger.error(e.errno)
+            logger.error("Is \"{}\" a valid minerl environment?".format(experiment))
         return None
     except URLError as e:
         logger.error("URL error encountered when downloading - please try again")

--- a/minerl/data/util/__init__.py
+++ b/minerl/data/util/__init__.py
@@ -108,7 +108,13 @@ def download_with_resume(urls, file_path, hash=None, timeout=10):
         i = np.argmin(latency)
     else:
         logging.warning('Re-checking mirrors, latency above 0.1s')
-        i = np.argmin([time_request(url, timeout=30) for url in urls])
+        latency = [time_request(url, timeout=30) for url in urls]
+        i = np.argmin(latency)
+        if min(latency) >= 1000 * 1000 * 1000:
+            logging.error('Unable to find valid mirror! Tried ...')
+            for url in urls:
+                logging.error('{}'.format(url))
+            raise requests.HTTPError
 
     logging.debug('Picked {}'.format(urls[i]))
     url = urls[i]

--- a/tests/local/handler_test.py
+++ b/tests/local/handler_test.py
@@ -254,4 +254,4 @@ def test_env(environment='MineRLObtainTest-v0', interactive=False):
     
 
 if __name__ == '__main__':
-    test_env()
+    test_wrapped_env()


### PR DESCRIPTION
Fix dataset url path for experiment downloading
Experiment URL had extra 'minerl' in URL, removed this for future package
Updated download script to error when all mirrors report HTTP errors with specified file
Concurrently download from mirrors to save some seconds in picking mirror