### PR TITLE
Fix VectorObf envs timing out (issue #319)

### DIFF
--- a/minerl/herobraine/wrapper.py
+++ b/minerl/herobraine/wrapper.py
@@ -17,8 +17,9 @@ class EnvWrapper(EnvSpec):
             self._unwrap_act_fn = self.env_to_wrap.unwrap_action
             self._unwrap_obs_fn = self.env_to_wrap.unwrap_observation
 
-        super().__init__(self._update_name(env_to_wrap.name), env_to_wrap.xml, max_episode_steps=None,
-                         reward_threshold=None)
+        super().__init__(self._update_name(env_to_wrap.name), env_to_wrap.xml,
+                         max_episode_steps=env_to_wrap.max_episode_steps,
+                         reward_threshold=env_to_wrap.reward_threshold)
 
     @abc.abstractmethod
     def _update_name(self, name: str) -> str:


### PR DESCRIPTION
Fixes #319 

Updates EnvWrapper to use environment's `max_episode_steps` and `reward_threshold` (like `xml` was passed), rather than forcing them to `None`