### PR TITLE
Fix data_pipeline.py memory issue

### DIFF
--- a/minerl/data/data_pipeline.py
+++ b/minerl/data/data_pipeline.py
@@ -378,9 +378,10 @@ class DataPipeline:
         """
         # Todo: Not implemented/
         for epoch in (range(num_epochs) if num_epochs > 0 else forever()):
-            # We can't use multiprocessing.Queue as it can't be passed through pipes
-            # and we wish to use concurrent.futures.ProcessPoolExecutor, so we use
-            # multiprocessing.Manager that can create queues that can be passed through pipes.
+            # We can't use multiprocessing.Queue as it can't be passed through
+            # pipes and we wish to use concurrent.futures.ProcessPoolExecutor,
+            # so we use multiprocessing.Manager that can create queues that
+            # can be passed through pipes.
             manager = multiprocessing.Manager()
             trajectory_queue = manager.Queue(maxsize=preload_buffer_size)
 
@@ -395,7 +396,8 @@ class DataPipeline:
                         done=d
                     )
 
-            jobs = [(f, -1, trajectory_queue) for f in self._get_all_valid_recordings(self.data_dir)]
+            jobs = [(f, -1, trajectory_queue)
+                     for f in self._get_all_valid_recordings(self.data_dir)]
             np.random.shuffle(jobs)
             trajectory_loader = minerl.data.util.OrderedJobStreamer(
                 job,

--- a/minerl/data/data_pipeline.py
+++ b/minerl/data/data_pipeline.py
@@ -397,7 +397,7 @@ class DataPipeline:
                     )
 
             jobs = [(f, -1, trajectory_queue)
-                     for f in self._get_all_valid_recordings(self.data_dir)]
+                    for f in self._get_all_valid_recordings(self.data_dir)]
             np.random.shuffle(jobs)
             trajectory_loader = minerl.data.util.OrderedJobStreamer(
                 job,

--- a/minerl/data/data_pipeline.py
+++ b/minerl/data/data_pipeline.py
@@ -391,7 +391,10 @@ class DataPipeline:
 
             def traj_iter():
                 for _ in jobs:
-                    s, a, r, sp1, d = trajectory_queue.get()
+                    data_tuple = trajectory_queue.get()
+                    if data_tuple is None:
+                        continue
+                    s, a, r, sp1, d = data_tuple
                     yield dict(
                         obs=s,
                         act=a,

--- a/minerl/data/data_pipeline.py
+++ b/minerl/data/data_pipeline.py
@@ -378,14 +378,6 @@ class DataPipeline:
             Generator: A generator that yields (sarsd) batches
         """
         # Todo: Not implemented/
-        def loader_func(input_queue, output_queue):
-            while True:
-                arg = input_queue.get()
-                if arg[0] == "SHUTDOWN":
-                    break
-                output = DataPipeline._load_data_pyfunc(*arg)
-                output_queue.put(output)
-
         input_queue = multiprocessing.Queue()
         trajectory_queue = multiprocessing.Queue(maxsize=preload_buffer_size)
 
@@ -501,5 +493,10 @@ class DataPipeline:
             "The `DataPipeline.sarsd_iter` method is deprecated! Please use DataPipeline.batch_iter().")
 
 
-def job(arg):
-    return DataPipeline._load_data_pyfunc(*arg)
+def loader_func(input_queue, output_queue):
+    while True:
+        arg = input_queue.get()
+        if arg[0] == "SHUTDOWN":
+            break
+        output = DataPipeline._load_data_pyfunc(*arg)
+        output_queue.put(output)

--- a/minerl/data/util/__init__.py
+++ b/minerl/data/util/__init__.py
@@ -201,12 +201,13 @@ class OrderedJobStreamer(threading.Thread):
                     raise future.exception()
                 res = future.result()
 
-                while not self._should_exit:
-                    try:
-                        self.output_queue.put(res, block=True, timeout=1)
-                        break
-                    except queue.Full:
-                        pass
+                if res is not None:
+                    while not self._should_exit:
+                        try:
+                            self.output_queue.put(res, block=True, timeout=1)
+                            break
+                        except queue.Full:
+                            pass
                         
             return
         except Exception:

--- a/minerl/data/util/__init__.py
+++ b/minerl/data/util/__init__.py
@@ -201,13 +201,12 @@ class OrderedJobStreamer(threading.Thread):
                     raise future.exception()
                 res = future.result()
 
-                if res is not None:
-                    while not self._should_exit:
-                        try:
-                            self.output_queue.put(res, block=True, timeout=1)
-                            break
-                        except queue.Full:
-                            pass
+                while not self._should_exit:
+                    try:
+                        self.output_queue.put(res, block=True, timeout=1)
+                        break
+                    except queue.Full:
+                        pass
                         
             return
         except Exception:


### PR DESCRIPTION
Related to #356, should fix it for python 3.6. ~Workers still don't exit correctly in python >=3.7, but that doesn't cause _that significant_ memory leaks as far as I can tell.~

edit: 
Workers exit correctly now in python >= 3.7.
Closes #356. Closes #349. 