### PR TITLE
Fixed mob-spawn issue by unregistering the ServerStateMachine

### DIFF
--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
@@ -1302,6 +1302,7 @@ public class ServerStateMachine extends StateMachine
         protected void execute()
         {
             // Put in all cleanup code here.
+            MinecraftForge.EVENT_BUS.unregister(ServerStateMachine.this);
             ServerStateMachine.this.currentMissionInit = null;
             
             // TODO (R): Kick all of the clients out?


### PR DESCRIPTION
This fix should make sure that mobs can still spawn, even after the ServerStateMachine is recreated. Previously, old state-machines would continue to be subscribed to the MinecraftForge.EVENT_BUS, causing them to handle events not mend for them (and rejecting mob spawning as a result).