### PR TITLE
download2: Add docstring; mkdir parents too

### DIFF
--- a/minerl/data/pipeline/download2.py
+++ b/minerl/data/pipeline/download2.py
@@ -4,8 +4,8 @@ For internal use only. Requires privileged AWS credentials.
 This script syncs recorded player trajectories (raw format) from the
 "s3://pizza-party" bucket to the DOWNLOAD_DIR, ~/minerl.data/downloaded_sync/.
 
-Other scripts can process these downloaded trajectories to a format that is usable by
-`minerl.data.make()` (i.e. `minerl.data.DataPipeline`).
+Other scripts can process these downloaded trajectories to a format that is
+usable by `minerl.data.make()` (i.e. `minerl.data.DataPipeline`).
 
 Protip: If you need to use a particular AWS profile for this script, execute
 `export AWS_PROFILE=$minerl_profile` before running.

--- a/minerl/data/pipeline/download2.py
+++ b/minerl/data/pipeline/download2.py
@@ -1,14 +1,24 @@
+"""
+For internal use only. Requires privileged AWS credentials.
+
+This script syncs recorded player trajectories (raw format) from the
+"s3://pizza-party" bucket to the DOWNLOAD_DIR, ~/minerl.data/downloaded_sync/.
+
+Other scripts can process these downloaded trajectories to a format that is usable by
+`minerl.data.make()` (i.e. `minerl.data.DataPipeline`).
+
+Protip: If you need to use a particular AWS profile for this script, execute
+`export AWS_PROFILE=$minerl_profile` before running.
+"""
+
 import boto3
 import tqdm
-import botocore
-import string
 import os
 import subprocess
 import time
 from pathlib import Path
-from minerl.data.util.constants import BASE_DIR, DOWNLOAD_DIR, OUTPUT_DIR, BUCKET_NAME
+from minerl.data.util.constants import DOWNLOAD_DIR, BUCKET_NAME
 
-J = os.path.join
 
 s3 = boto3.resource('s3')
 bucket = s3.Bucket(BUCKET_NAME)
@@ -16,10 +26,11 @@ bucket = s3.Bucket(BUCKET_NAME)
 
 def main():
     bucket_prefixes = ['2018', '2019', '2020']
-    Path(DOWNLOAD_DIR).mkdir(exist_ok=True)
+    Path(DOWNLOAD_DIR).mkdir(exist_ok=True, parents=True)
 
     print("Downloading to {}".format(DOWNLOAD_DIR))
 
+    # Output the number of files before downloading.
     obj_count = 0
     new_objs = 0
     files_to_download = []


### PR DESCRIPTION
Some minor changes as I'm going through the data processing pipeline.

* Adds some documentation/tips that could be useful for others.
* removed some unused imports
* fixed an out-of-the-box ~"parent directory doesn't exist" Exception by building parents of DOWNLOAD_DIR too.
