### PR TITLE
Use button fix

### DIFF
--- a/minerl/Malmo/Minecraft/run/options.txt
+++ b/minerl/Malmo/Minecraft/run/options.txt
@@ -39,7 +39,7 @@ chatHeightFocused:1.0
 chatHeightUnfocused:0.44366196
 chatScale:1.0
 chatWidth:1.0
-showInventoryAchievementHint:true
+showInventoryAchievementHint:false
 mipmapLevels:4
 forceUnicodeFont:false
 reducedDebugInfo:false

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoModClient.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoModClient.java
@@ -19,6 +19,7 @@
 
 package com.microsoft.Malmo.Client;
 
+import net.minecraft.client.gui.GuiGameOver;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -251,7 +252,7 @@ public class MalmoModClient
     public void onGuiOpenEvent(GuiOpenEvent event){
         if(this.stateMachine.getStableState() == ClientState.RUNNING){
             Logger logger = Logger.getLogger("MalmoModClient.onGuiOpenEvent");
-            if (event != null && event.getGui() != null) {
+            if (event != null && event.getGui() != null && !(event.getGui() instanceof GuiGameOver)) {
                 logger.log(Level.WARNING, "GUI Window " + event.getGui().getClass().getSimpleName() + " opened!");
                 throw new AssertionError("GUI Window " + event.getGui().getClass().getSimpleName() + " opened!");
             }

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoModClient.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoModClient.java
@@ -251,8 +251,10 @@ public class MalmoModClient
     public void onGuiOpenEvent(GuiOpenEvent event){
         if(this.stateMachine.getStableState() == ClientState.RUNNING){
             Logger logger = Logger.getLogger("MalmoModClient.onGuiOpenEvent");
-            if (event != null && event.getGui() != null)
+            if (event != null && event.getGui() != null) {
                 logger.log(Level.WARNING, "GUI Window " + event.getGui().getClass().getSimpleName() + " opened!");
+                throw new AssertionError("GUI Window " + event.getGui().getClass().getSimpleName() + " opened!");
+            }
         }
 
     }

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
@@ -1,0 +1,27 @@
+
+
+package com.microsoft.Malmo.Mixins;
+
+
+import com.microsoft.Malmo.Utils.SeedHelper;
+import net.minecraft.client.resources.DefaultPlayerSkin;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Random;
+import java.util.UUID;
+
+
+@Mixin(DefaultPlayerSkin.class)
+public abstract class MixinRandomSkinTexture {
+    // Randomize the skin for agents ignoring UUID
+    @Inject(method = "isSlimSkin", at = @At("HEAD"), cancellable = true)
+    private static void isSlimSkin(UUID playerUUID, CallbackInfoReturnable<Boolean> cir){
+        Random rand = new Random();
+        cir.setReturnValue(rand.nextBoolean());
+        cir.cancel();
+    }
+  
+}

--- a/minerl/Malmo/Minecraft/src/main/resources/mixins.overclocking.malmomod.json
+++ b/minerl/Malmo/Minecraft/src/main/resources/mixins.overclocking.malmomod.json
@@ -6,6 +6,7 @@
     "MixinLargeInventory",
     "MixinMinecraftGameloop",
     "MixinMinecraftServerRun",
+    "MixinNoGuiInteract",
     "MixinRandomSkinTexture",
     "MixinWorldProviderSpawn"
   ],

--- a/minerl/Malmo/Minecraft/src/main/resources/mixins.overclocking.malmomod.json
+++ b/minerl/Malmo/Minecraft/src/main/resources/mixins.overclocking.malmomod.json
@@ -6,7 +6,6 @@
     "MixinLargeInventory",
     "MixinMinecraftGameloop",
     "MixinMinecraftServerRun",
-    "MixinNoGuiInteract",
     "MixinRandomSkinTexture",
     "MixinWorldProviderSpawn"
   ],

--- a/minerl/Malmo/Minecraft/src/main/resources/mixins.overclocking.malmomod.json
+++ b/minerl/Malmo/Minecraft/src/main/resources/mixins.overclocking.malmomod.json
@@ -2,12 +2,13 @@
   "required": true,
   "package": "com.microsoft.Malmo.Mixins",
   "mixins": [
-    "MixinMinecraftServerRun",
-    "MixinMinecraftGameloop",
-    "MixinWorldProviderSpawn",
     "MixinEntityRandom",
+    "MixinLargeInventory",
+    "MixinMinecraftGameloop",
+    "MixinMinecraftServerRun",
     "MixinNoGuiInteract",
-    "MixinLargeInventory"
+    "MixinRandomSkinTexture",
+    "MixinWorldProviderSpawn"
   ],
   "server": [
   ],

--- a/minerl/herobraine/hero/mc.py
+++ b/minerl/herobraine/hero/mc.py
@@ -532,8 +532,16 @@ MINERL_ITEM_MAP = sorted(["none"] + ALL_ITEMS)
 ITEMS_BY_CATEGORY = {
     # Items which take 2 seconds to USE
     'edible': [item['type'] for item in all_data['items'] if item['useAction'] in {'EAT', 'DRINK'}],
-    # Items which have ongoing effect when equipped
-    'tool': [item['type'] for item in all_data['items'] if item['tab'] in {'tools', 'combat'}]
+    # Items which have ongoing effect when equipped (includes armor)
+    'tool': [item['type'] for item in all_data['items'] if item['tab'] in {'tools', 'combat'}],
+    # Items which are used for building
+    'building_block': [item['type'] for item in all_data['items'] if item['tab'] in {'buildingBlock'}],
+    # Redstone items (doors, buttons, levers)
+    'redstone': [item['type'] for item in all_data['items'] if item['tab'] in {'redstone'}],
+    # Brewing items
+    'brewing': [item['type'] for item in all_data['items'] if item['tab'] in {'brewing'}],
+    # Decoration items (includes torch)
+    'decoration': [item['type'] for item in all_data['items'] if item['tab'] in {'decoration'}]
 }
 
 # Check that all edible items have the same maxUseDuration


### PR DESCRIPTION
This fix prevents any agent from opening a gui window using the use button in Minecraft.
This prevents the agents from placing signs (via equipping and pressing the use button) as well as opening gui containers such as chests, hoppers, mine-cart furnaces, ect.

Also adds a randomization to the agent's default texture to prevent bais, and adds some nice item classes to mc.constants

The meat of the fix has been merged already into dev 