### PR TITLE
multi-agent reward handlers 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -284,7 +284,7 @@ tests/logs/
 jenkins_home/
 
 #eclipse
-Malmo/Minecraft/*.launch
+minerl/Malmo/Minecraft/*.launch
 *minerl_watchers/
 caches/
 native/

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/DiscreteMovementCommandsImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/DiscreteMovementCommandsImplementation.java
@@ -27,6 +27,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.MoverType;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
@@ -40,6 +41,7 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.eventhandler.Event;
@@ -66,17 +68,18 @@ public class DiscreteMovementCommandsImplementation extends CommandBase implemen
     private boolean isOverriding;
     DiscreteMovementCommands params;
 
-    public static class DiscretePartialMoveEvent extends Event
+    public static class DiscretePartialMoveEvent extends PlayerEvent
     {
         public final double x;
         public final double y;
         public final double z;
 
-        public DiscretePartialMoveEvent(double x, double y, double z)
+        public DiscretePartialMoveEvent(EntityPlayer player)
         {
-            this.x = x;
-            this.y = y;
-            this.z = z;
+            super(player);
+            this.x = player.posX;
+            this.y = player.posY;
+            this.z = player.posZ;
         }
     }
 
@@ -391,7 +394,8 @@ public class DiscreteMovementCommandsImplementation extends CommandBase implemen
                             java.util.List<ItemStack> items = block.getDrops(player.world, hitPos, iblockstate, 0);
                             for (ItemStack item : items)
                             {
-                                RewardForCollectingItemImplementation.GainItemEvent event = new RewardForCollectingItemImplementation.GainItemEvent(item);
+                            RewardForCollectingItemImplementation.GainItemEvent event = new RewardForCollectingItemImplementation.GainItemEvent(
+                                    player, item);
                                 MinecraftForge.EVENT_BUS.post(event);
                             }
                         }
@@ -487,7 +491,7 @@ public class DiscreteMovementCommandsImplementation extends CommandBase implemen
 
                     // Before we do that, fire off a message - this will give the TouchingBlockType handlers
                     // a chance to react to the current position:
-                    DiscretePartialMoveEvent event = new DiscretePartialMoveEvent(player.posX, player.posY, player.posZ);
+                    DiscretePartialMoveEvent event = new DiscretePartialMoveEvent(player);
                     MinecraftForge.EVENT_BUS.post(event);
                     // Now adjust the player:
                     player.move(MoverType.SELF, oldX - newX, 0.0, oldZ - newZ);

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/InventoryCommandsImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/InventoryCommandsImplementation.java
@@ -177,12 +177,14 @@ public class InventoryCommandsImplementation extends CommandGroup
         {
             if (message.itemsGained != null)
             {
-                RewardForCollectingItemImplementation.GainItemEvent event = new RewardForCollectingItemImplementation.GainItemEvent(message.itemsGained);
+                RewardForCollectingItemImplementation.GainItemEvent event = new RewardForCollectingItemImplementation.GainItemEvent(
+                        ctx.getServerHandler().playerEntity, message.itemsGained);
                 MinecraftForge.EVENT_BUS.post(event);
             }
             if (message.itemsLost != null)
             {
-                RewardForDiscardingItemImplementation.LoseItemEvent event = new RewardForDiscardingItemImplementation.LoseItemEvent(message.itemsLost);
+                RewardForDiscardingItemImplementation.LoseItemEvent event = new RewardForDiscardingItemImplementation.LoseItemEvent(
+                        ctx.getServerHandler().playerEntity, message.itemsLost);
                 MinecraftForge.EVENT_BUS.post(event);
             }
             return null;

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardBase.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardBase.java
@@ -10,6 +10,9 @@ import com.microsoft.Malmo.MalmoMod.MalmoMessageType;
 import com.microsoft.Malmo.MissionHandlerInterfaces.IRewardProducer;
 import com.microsoft.Malmo.Schemas.MissionInit;
 
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
 public class RewardBase extends HandlerBase implements IRewardProducer
 {
     private String agentName;
@@ -85,6 +88,7 @@ public class RewardBase extends HandlerBase implements IRewardProducer
     public void prepare(MissionInit missionInit)
     {
         this.agentName = missionInit.getMission().getAgentSection().get(missionInit.getClientRole()).getName();
+        System.out.println("Preparing reward " + this + " with agent name " + this.agentName);
     }
 
     @Override
@@ -114,6 +118,14 @@ public class RewardBase extends HandlerBase implements IRewardProducer
     {
         float adjusted_reward = adjustAndDistributeReward(reward, dimension, distribution);
         addCachedReward(dimension, adjusted_reward);
+    }
+
+    protected void checkCorrectPlayer(String eventPlayer, Event event) {
+        if (!eventPlayer.equals(agentName)) {
+            throw new RuntimeException("event " + event + " corresponds to agent " + eventPlayer
+                    + ", so it is not mine. I am "
+                    + agentName);
+        }
     }
 
     @Override

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForCollectingItemImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForCollectingItemImplementation.java
@@ -19,20 +19,9 @@
 
 package com.microsoft.Malmo.MissionHandlers;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
 import java.util.Map;
 
 import javax.xml.bind.DatatypeConverter;
-
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
-import net.minecraftforge.fml.common.eventhandler.Event;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.network.ByteBufUtils;
 
 import com.microsoft.Malmo.MalmoMod;
 import com.microsoft.Malmo.MalmoMod.IMalmoMessageListener;
@@ -41,11 +30,26 @@ import com.microsoft.Malmo.MissionHandlerInterfaces.IRewardProducer;
 import com.microsoft.Malmo.Schemas.BlockOrItemSpecWithReward;
 import com.microsoft.Malmo.Schemas.MissionInit;
 import com.microsoft.Malmo.Schemas.RewardForCollectingItem;
-import com.microsoft.Malmo.Utils.TimeHelper;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.network.ByteBufUtils;
 
 public class RewardForCollectingItemImplementation extends RewardForItemBase implements IRewardProducer, IMalmoMessageListener
 {
     private RewardForCollectingItem params;
+
+    public RewardForCollectingItemImplementation() {
+        // prohibit instantiation - use RewardForPossessingItem instead
+        throw new RuntimeException("Do not use RewardForCollectingItem, use RewardForPosssessingItem instead");
+    };
 
     @Override
     public void onMessage(MalmoMessageType messageType, Map<String, String> data) 
@@ -63,7 +67,7 @@ public class RewardForCollectingItemImplementation extends RewardForItemBase imp
         }
     }
     
-    public static class GainItemEvent extends Event {
+    public static class GainItemEvent extends PlayerEvent {
         public final ItemStack stack;
 
         /**
@@ -71,7 +75,8 @@ public class RewardForCollectingItemImplementation extends RewardForItemBase imp
          */
         public int cause = 0;
 
-        public GainItemEvent(ItemStack stack) {
+        public GainItemEvent(EntityPlayer player, ItemStack stack) {
+            super(player);
             this.stack = stack;
         }
 
@@ -96,8 +101,8 @@ public class RewardForCollectingItemImplementation extends RewardForItemBase imp
     @SubscribeEvent
     public void onGainItem(GainItemEvent event)
     {
-
         // TimeHelper.SyncManager.debugLog("----------------------------> onItemCraft!");
+        checkCorrectPlayer(event.getEntityPlayer().getName(), event);
         if (event.stack != null)
         {
             accumulateReward(this.params.getDimension(), event.stack);

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForCollectingItemQuantityImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForCollectingItemQuantityImplementation.java
@@ -48,24 +48,28 @@ public class RewardForCollectingItemQuantityImplementation extends RewardForItem
 
     @SubscribeEvent
     public void onGainItem(RewardForCollectingItemImplementation.GainItemEvent event) {
+        checkCorrectPlayer(event.getEntityPlayer().getName(), event);
         if (event.stack != null && event.cause == 0)
             checkForMatch(event.stack);
     }
 
     @SubscribeEvent
     public void onPickupItem(EntityItemPickupEvent event) {
+        checkCorrectPlayer(event.getEntityPlayer().getName(), event);
         if (event.getItem() != null && event.getEntityPlayer() instanceof EntityPlayerMP)
             checkForMatch(event.getItem().getEntityItem());
     }
 
     @SubscribeEvent
     public void onItemCraft(PlayerEvent.ItemCraftedEvent event) {
+        checkCorrectPlayer(event.player.getName(), event);
         if (event.player instanceof EntityPlayerMP && !event.crafting.isEmpty())
             checkForMatch(event.crafting);
     }
 
     @SubscribeEvent
     public void onItemSmelt(PlayerEvent.ItemSmeltedEvent event) {
+        checkCorrectPlayer(event.player.getName(), event);
         if (event.player instanceof EntityPlayerMP && !event.smelting.isEmpty())
             checkForMatch(event.smelting);
     }

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForCraftingItemImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForCraftingItemImplementation.java
@@ -46,6 +46,7 @@ public class RewardForCraftingItemImplementation extends RewardForItemBase imple
 
     @SubscribeEvent
     public void onItemCraft(PlayerEvent.ItemCraftedEvent event) {
+        checkCorrectPlayer(event.player.getName(), event);
         if (event.player instanceof EntityPlayerMP && !event.crafting.isEmpty())
             checkForMatch(event.crafting);
     }

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForDamagingEntityImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForDamagingEntityImplementation.java
@@ -20,6 +20,10 @@ public class RewardForDamagingEntityImplementation extends RewardBase implements
     RewardForDamagingEntity params;
     Map<MobWithReward, Float> damages = new HashMap<MobWithReward, Float>();
 
+    public RewardForDamagingEntityImplementation() {
+        throw new RuntimeException("Implementation is is single-agent and needs to be fixed for multi-agent case");
+    }
+
     @Override
     public boolean parseParameters(Object params)
     {

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForDiscardingItemImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForDiscardingItemImplementation.java
@@ -26,10 +26,12 @@ import java.util.Map;
 
 import javax.xml.bind.DatatypeConverter;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -63,7 +65,7 @@ public class RewardForDiscardingItemImplementation extends RewardForItemBase imp
         }
     }
     
-    public static class LoseItemEvent extends Event
+    public static class LoseItemEvent extends PlayerEvent
     {
         public final ItemStack stack;
 
@@ -72,8 +74,9 @@ public class RewardForDiscardingItemImplementation extends RewardForItemBase imp
          */
         public int cause = 0;
 
-        public LoseItemEvent(ItemStack stack)
+        public LoseItemEvent(EntityPlayer player, ItemStack stack)
         {
+            super(player);
             this.stack = stack;
         }
 
@@ -99,6 +102,7 @@ public class RewardForDiscardingItemImplementation extends RewardForItemBase imp
     @SubscribeEvent
     public void onLoseItem(LoseItemEvent event)
     {
+        checkCorrectPlayer(event.getEntityPlayer().getName(), event);
         if (event.stack != null)
         {
             accumulateReward(this.params.getDimension(), event.stack);
@@ -108,6 +112,7 @@ public class RewardForDiscardingItemImplementation extends RewardForItemBase imp
     @SubscribeEvent
     public void onTossItem(ItemTossEvent event)
     {
+        checkCorrectPlayer(event.getPlayer().getName(), event);
         if (event.getEntityItem() != null && event.getPlayer() instanceof EntityPlayerMP)
         {
             ItemStack stack = event.getEntityItem().getEntityItem();
@@ -118,6 +123,7 @@ public class RewardForDiscardingItemImplementation extends RewardForItemBase imp
     @SubscribeEvent
     public void onPlaceBlock(BlockEvent.PlaceEvent event)
     {
+        checkCorrectPlayer(event.getPlayer().getName(), event);
         if (event.getPlayer().getHeldItem(event.getHand()) != null && event.getPlayer() instanceof EntityPlayerMP )
         {
             // This event is received on the server side, so we need to pass it to the client.

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForDistanceTraveledToCompassTargetImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForDistanceTraveledToCompassTargetImplementation.java
@@ -2,27 +2,13 @@ package com.microsoft.Malmo.MissionHandlers;
 
 
 
-import net.minecraft.util.ResourceLocation;
-
-import javax.annotation.Nullable;
-
 import com.microsoft.Malmo.Schemas.MissionInit;
 import com.microsoft.Malmo.Schemas.RewardForDistanceTraveledToCompassTarget;
 
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.item.EntityItemFrame;
-import net.minecraft.item.IItemPropertyGetter;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class RewardForDistanceTraveledToCompassTargetImplementation extends RewardBase
 {

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForPossessingItemImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForPossessingItemImplementation.java
@@ -316,5 +316,6 @@ public class RewardForPossessingItemImplementation extends RewardForItemBase
         super.cleanup();
         MinecraftForge.EVENT_BUS.unregister(this);
         MalmoMod.MalmoMessageHandler.deregisterForMessage(this, MalmoMessageType.SERVER_COLLECTITEM);
+        MalmoMod.MalmoMessageHandler.deregisterForMessage(this, MalmoMessageType.SERVER_DISCARDITEM);
     }
 }

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForSmeltingItemImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForSmeltingItemImplementation.java
@@ -45,6 +45,7 @@ public class RewardForSmeltingItemImplementation extends RewardForItemBase imple
 
     @SubscribeEvent
     public void onItemSmelt(PlayerEvent.ItemSmeltedEvent event) {
+        checkCorrectPlayer(event.player.getName(), event);
         if (event.player instanceof EntityPlayerMP && !event.smelting.isEmpty())
             checkForMatch(event.smelting);
     }

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForTouchingBlockTypeImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/RewardForTouchingBlockTypeImplementation.java
@@ -132,6 +132,7 @@ public class RewardForTouchingBlockTypeImplementation extends RewardBase impleme
     @SubscribeEvent
     public void onDiscretePartialMoveEvent(DiscreteMovementCommandsImplementation.DiscretePartialMoveEvent event)
     {
+        checkCorrectPlayer(event.getEntityPlayer().getName(), event);
         MultidimensionalReward reward = new MultidimensionalReward();
         calculateReward(reward);
         addCachedReward(reward);

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/CraftingHelper.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/CraftingHelper.java
@@ -324,7 +324,8 @@ public class CraftingHelper {
                 }
             }
             ItemStack resultForReward = isIngredient.copy();
-            RewardForDiscardingItemImplementation.LoseItemEvent event = new RewardForDiscardingItemImplementation.LoseItemEvent(resultForReward);
+            RewardForDiscardingItemImplementation.LoseItemEvent event = new RewardForDiscardingItemImplementation.LoseItemEvent(
+                    player, resultForReward);
             MinecraftForge.EVENT_BUS.post(event);
         }
     }
@@ -473,12 +474,15 @@ public class CraftingHelper {
 
     /**
      * Attempt to craft the given recipe.<br>
-     * This pays no attention to tedious things like using the right crafting table / brewing stand etc, or getting the right shape.<br>
-     * It simply takes the raw ingredients out of the player's inventory, and inserts the output of the recipe, if possible.
+     * This pays no attention to tedious things like using the right crafting table
+     * / brewing stand etc, or getting the right shape.<br>
+     * It simply takes the raw ingredients out of the player's inventory, and
+     * inserts the output of the recipe, if possible.
      *
      * @param player the SERVER SIDE player that will do the crafting.
      * @param recipe the IRecipe we wish to craft.
-     * @return true if the recipe had an output, and the player had the required ingredients to create it; false otherwise.
+     * @return true if the recipe had an output, and the player had the required
+     *         ingred:xients to create it; false otherwise.
      */
     public static boolean attemptCrafting(EntityPlayerMP player, IRecipe recipe) {
         if (player == null || recipe == null)
@@ -495,7 +499,8 @@ public class CraftingHelper {
             ItemStack resultForInventory = is.copy();
             ItemStack resultForReward = is.copy();
             player.inventory.addItemStackToInventory(resultForInventory);
-            RewardForCollectingItemImplementation.GainItemEvent event = new RewardForCollectingItemImplementation.GainItemEvent(resultForReward);
+            RewardForCollectingItemImplementation.GainItemEvent event = new RewardForCollectingItemImplementation.GainItemEvent(
+                    player, resultForReward);
             event.setCause(1);
             MinecraftForge.EVENT_BUS.post(event);
 
@@ -621,7 +626,8 @@ public class CraftingHelper {
             ItemStack resultForInventory = isOutput.copy();
             ItemStack resultForReward = isOutput.copy();
             player.inventory.addItemStackToInventory(resultForInventory);
-            RewardForCollectingItemImplementation.GainItemEvent event = new RewardForCollectingItemImplementation.GainItemEvent(resultForReward);
+            RewardForCollectingItemImplementation.GainItemEvent event = new RewardForCollectingItemImplementation.GainItemEvent(
+                    player, resultForReward);
             event.setCause(2);
             MinecraftForge.EVENT_BUS.post(event);
 

--- a/minerl/env/_multiagent.py
+++ b/minerl/env/_multiagent.py
@@ -530,7 +530,8 @@ class _MultiAgentEnv(gym.Env):
                         <MaxPlayers>{}</MaxPlayers>
                     </HumanInteraction>""".format(self.interact_port, self.max_players))
                 # Update the xml
-                ss = agent_xml_etree.find(".//" + self.ns + 'ServerSection')
+                namespace = '{http://ProjectMalmo.microsoft.com}'
+                ss = agent_xml_etree.find(".//" + namespace + 'ServerSection')
                 ss.insert(0, hi)
 
             # inject mission dict into the xml

--- a/minerl/interactor/__main__.py
+++ b/minerl/interactor/__main__.py
@@ -2,8 +2,8 @@
 # Author: William H. Guss, Brandon Houghton
 
 import argparse
+from minerl.env._multiagent import _MultiAgentEnv
 from minerl.env.malmo import InstanceManager, MinecraftInstance, malmo_version
-from minerl.env.core import MineRLEnv
 from minerl.env import comms
 import os
 import socket
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 def request_interactor(instance, ip):
     sock = get_socket(instance)
-    MineRLEnv._hello(sock)
+    _MultiAgentEnv._TO_MOVE_hello(sock)
 
     comms.send_message(sock,
                        ("<Interact>" + ip + "</Interact>").encode())


### PR DESCRIPTION
a bunch of the java reward handlers compute the reward via subscribing to particular events via eventbus. When such events are generated server-side, reward for multi-agent environments can be misattributed (i.e. all the reward is accumulated by the client in the same java process as server, instead of going to the correct agent)

This PR:
- adds function to RewardBase that lets subclasses to check if the player that generated the reward is the same that instantiated the Reward class.  The logic is as follows - the Reward methods that are annottated with `SubscribeEvent` should either a) forward the reward to client via explicit message OR b) pass the check. 
- Fixes RewardForPossesingItem to send messages on obtaining and loosing the item 
- Deprecates RewardForCollectingItem