### PR TITLE
control distance between spawned agents

### DIFF
--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
@@ -888,6 +888,9 @@ public class ServerStateMachine extends StateMachine
                 double angle = rng.nextDouble() * 2.0 * Math.PI;
                 double Z = anchor.posZ + distance * Math.cos(angle);
                 double X = anchor.posX + distance * Math.sin(angle);
+                // ideally, should be determined by the width of the viewport, so that agents
+                // are in each
+                // other's field of view
                 double angleNoise = 20.0;
 
                 double Y = Minecraft.getMinecraft().world.getTopSolidOrLiquidBlock(new BlockPos(X, 0, Z)).getY();

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
@@ -809,6 +809,7 @@ public class ServerStateMachine extends StateMachine
 
         private void initialisePlayer(String username, String agentname)
         {
+            System.out.println("Initializing player with username " + username + " and agentname " + agentname);
             AgentSection as = getAgentSectionFromAgentName(agentname);
             EntityPlayerMP player = getPlayerFromUsername(username);
 
@@ -844,18 +845,83 @@ public class ServerStateMachine extends StateMachine
                 
                 // Set their initial position and speed:
                 PosAndDirection pos = as.getAgentStart().getPlacement();
+                NearPlayer nearPlayer = as.getAgentStart().getNearPlayer();
 
                 if (pos != null) {
-                    player.rotationYaw = pos.getYaw().floatValue();
-                    player.rotationPitch = pos.getPitch().floatValue();
-                    player.setPositionAndUpdate(pos.getX().doubleValue(),pos.getY().doubleValue(),pos.getZ().doubleValue());
-                    player.onUpdate();	// Needed to force scene to redraw
+                    if (nearPlayer != null) {
+                        throw new RuntimeException(
+                                "Either absolute starting position or NearAgent can be specified, but not both!");
+                    }
+                    setPlayerAbsolutePosition(player, pos);
+                } else if (nearPlayer != null) {
+                    setPlayerNearPlayer(player, nearPlayer);
                 }
                 player.setVelocity(0, 0, 0);	// Minimise chance of drift!
                 player.onUpdateEntity();
             }
         }
         
+        private void setPlayerAbsolutePosition(EntityPlayerMP player, PosAndDirection pos) {
+            player.rotationYaw = pos.getYaw().floatValue();
+            player.rotationPitch = pos.getPitch().floatValue();
+            player.setPositionAndUpdate(pos.getX().doubleValue(), pos.getY().doubleValue(), pos.getZ().doubleValue());
+            player.onUpdate(); // Needed to force scene to redraw
+        }
+
+        private void setPlayerNearPlayer(EntityPlayerMP player, NearPlayer np) {
+
+            if (player.getName().equals(np.getName())) {
+                // Player is next to themselves by default - no need for further action
+                return;
+            }
+            System.out.println("Setting player " + player.getName() + " next to " + np.getName());
+            double maxDistance = np.getMaxDistance();
+            double minDistance = np.getMinDistance();
+            double maxVertDistance = np.getMaxVertDistance();
+            int tries = 20;
+            EntityPlayerMP anchor = getPlayerFromUsername(np.getName());
+            anchor.onUpdate();
+
+            Random rng = new Random();
+            for (int i = 0; i < tries; i++) {
+                double distance = minDistance + rng.nextDouble() * (maxDistance - minDistance);
+                double angle = rng.nextDouble() * 2.0 * Math.PI;
+                double Z = anchor.posZ + distance * Math.cos(angle);
+                double X = anchor.posX + distance * Math.sin(angle);
+                double angleNoise = 20.0;
+
+                double Y = Minecraft.getMinecraft().world.getTopSolidOrLiquidBlock(new BlockPos(X, 0, Z)).getY();
+                System.out.println("Y = " + String.valueOf(Y) + ", anchor.posY = " + String.valueOf(anchor.posY)
+                        + ", anchor.posX = " + String.valueOf(anchor.posX) + ", anchor.posZ = "
+                        + String.valueOf(anchor.posZ));
+                if (np.isLookingAt()) {
+                    double yaw = -angle * 180.0 / Math.PI;
+                    double pitch = -Math.atan((anchor.posY - Y) / distance) * 180 / Math.PI;
+                    player.rotationYaw = (float) (180.0 + yaw + angleNoise * (rng.nextDouble() - 0.5));
+                    anchor.rotationYaw = (float) (yaw + angleNoise * (rng.nextDouble() - 0.5));
+                    player.rotationPitch = (float) (pitch + angleNoise * (rng.nextDouble() - 0.5));
+                    anchor.rotationPitch = -(float) (pitch + angleNoise * (rng.nextDouble() - 0.5));
+
+                    System.out.println(
+                            "Setting agents " + player.getName() + " and " + np.getName() + " looking at each other");
+                    System.out.println("With yaw " + String.valueOf(yaw) + " and pitch " + String.valueOf(pitch));
+
+                }
+                player.setPositionAndUpdate(X, Y, Z);
+                anchor.setPositionAndUpdate(anchor.posX, anchor.posY, anchor.posZ);
+                if (Math.abs(Y - anchor.posY) < maxVertDistance) {
+
+                    break;
+                }
+
+                System.out.println("(Attempt " + String.valueOf(i) + " of " + String.valueOf(tries)
+                        + "):  Failed to place agent " + player.getName() + " within vertical distance "
+                        + String.valueOf(maxVertDistance) + " of anchor player " + np.getName());
+            }
+
+            player.onUpdate();
+        }
+
         private boolean disablePlayerGracePeriod(EntityPlayerMP player)
         {
             // Are we in the dev environment or deployed?

--- a/minerl/Malmo/Schemas/Mission.xsd
+++ b/minerl/Malmo/Schemas/Mission.xsd
@@ -157,6 +157,48 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>
+                <xs:element name="NearPlayer" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:all>
+                            <xs:element name="Name" type="xs:string" minOccurs="1" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Start the player next to player with this name
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="MinDistance" type="xs:double">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Min horizontal distance to the anchor player
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="MaxDistance" type="xs:double">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Max horizontal distance to the anchor player
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="MaxVertDistance" type="xs:double">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Max vertical distance to the anchor player
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                             <xs:element name="LookingAt" type="xs:boolean">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        If true, orient this player such to be looking at the anchor player.
+                                        Does not always guarantee visibility if there are obstacles in the way
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:all>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="Inventory" minOccurs="0" maxOccurs="1">
                     <xs:complexType>
                         <xs:choice minOccurs="0"

--- a/minerl/herobraine/hero/handlers/agent/start.py
+++ b/minerl/herobraine/hero/handlers/agent/start.py
@@ -93,3 +93,24 @@ class AgentStartPlacement(Handler):
         self.y = y
         self.z = x
         self.yaw = yaw
+
+
+class AgentStartNear(Handler):
+    def to_string(self) -> str:
+        return f"agent_start_near({self.anchor_name}, h {self.min_distance} - {self.max_distance}, v {self.max_vert_distance})"
+
+    def xml_template(self) -> str:
+        return str(
+            """<NearPlayer>
+                    <Name>{{anchor_name}}</Name>
+                    <MaxDistance>{{max_distance}}</MaxDistance>
+                    <MinDistance>{{min_distance}}</MinDistance>
+                    <MaxVertDistance>{{max_vert_distance}}</MaxVertDistance>
+                    <LookingAt>true</LookingAt>
+               </NearPlayer>""")
+
+    def __init__(self, anchor_name="MineRLAgent0", min_distance=2, max_distance=10, max_vert_distance=3):
+        self.anchor_name = anchor_name
+        self.min_distance = min_distance
+        self.max_distance = max_distance
+        self.max_vert_distance = max_vert_distance


### PR DESCRIPTION
Adds and implements NearAgent mission xml element that allows
 - agents to be placed within certain horizontal and vertical distance from each other
 - make agents see each other at the start

NOTE: it is not exactly clear how to generalize "LookingAt" for >2 agents case.