### PR TITLE
prevent agent skin blinking

### DIFF
--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MalmoMod.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MalmoMod.java
@@ -231,6 +231,7 @@ public class MalmoMod
         SERVER_SHARE_REWARD,        // Server has received a reward from a client and is distributing it to the other agents
         SERVER_YOUR_TURN,           // Server turn scheduler is telling client that it is their go next
         SERVER_SOMEOTHERMESSAGE,
+        SERVER_COMMON_SEED,
         CLIENT_AGENTREADY,			// Client response to server's ready request
         CLIENT_AGENTRUNNING,		// Client has just started running
         CLIENT_AGENTSTOPPED,		// Client response to server's stop request

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
@@ -17,14 +17,18 @@ import net.minecraft.client.resources.DefaultPlayerSkin;
 @Mixin(DefaultPlayerSkin.class)
 public abstract class MixinRandomSkinTexture {
     // Randomize the skin for agents ignoring UUID
-    private static Boolean isSlim = null;
+    private static Integer skinSeed = null;
     @Inject(method = "isSlimSkin", at = @At("HEAD"), cancellable = true)
     private static void isSlimSkin(UUID playerUUID, CallbackInfoReturnable<Boolean> cir){
-        if (isSlim == null) {
+        if (skinSeed == null) {
+            // TODO now this is not blinking, and randomized, but not consistent between
+            // clients. Ideally, we should somehow sync this between clients -
+            // is there any pseudo-random number in the minecraft world we
+            // could base this on?
             Random rand = new Random();
-            isSlim = rand.nextBoolean();
+            skinSeed = rand.nextInt();
         }
-        cir.setReturnValue(isSlim);
+        cir.setReturnValue(((playerUUID.hashCode() + skinSeed) & 1) == 0);
         cir.cancel();
     }
   

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
@@ -3,24 +3,28 @@
 package com.microsoft.Malmo.Mixins;
 
 
-import com.microsoft.Malmo.Utils.SeedHelper;
-import net.minecraft.client.resources.DefaultPlayerSkin;
+import java.util.Random;
+import java.util.UUID;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Random;
-import java.util.UUID;
+import net.minecraft.client.resources.DefaultPlayerSkin;
 
 
 @Mixin(DefaultPlayerSkin.class)
 public abstract class MixinRandomSkinTexture {
     // Randomize the skin for agents ignoring UUID
+    private static Boolean isSlim = null;
     @Inject(method = "isSlimSkin", at = @At("HEAD"), cancellable = true)
     private static void isSlimSkin(UUID playerUUID, CallbackInfoReturnable<Boolean> cir){
-        Random rand = new Random();
-        cir.setReturnValue(rand.nextBoolean());
+        if (isSlim == null) {
+            Random rand = new Random();
+            isSlim = rand.nextBoolean();
+        }
+        cir.setReturnValue(isSlim);
         cir.cancel();
     }
   

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
@@ -11,24 +11,19 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import com.microsoft.Malmo.MalmoMod;
+import com.microsoft.Malmo.Utils.SeedHelper;
+
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.DefaultPlayerSkin;
 
 
 @Mixin(DefaultPlayerSkin.class)
 public abstract class MixinRandomSkinTexture {
     // Randomize the skin for agents ignoring UUID
-    private static Integer skinSeed = null;
     @Inject(method = "isSlimSkin", at = @At("HEAD"), cancellable = true)
     private static void isSlimSkin(UUID playerUUID, CallbackInfoReturnable<Boolean> cir){
-        if (skinSeed == null) {
-            // TODO now this is not blinking, and randomized, but not consistent between
-            // clients. Ideally, we should somehow sync this between clients -
-            // is there any pseudo-random number in the minecraft world we
-            // could base this on?
-            Random rand = new Random();
-            skinSeed = rand.nextInt();
-        }
-        cir.setReturnValue(((playerUUID.hashCode() + skinSeed) & 1) == 0);
+        cir.setReturnValue(((playerUUID.hashCode() + SeedHelper.getWorldSeed()) & 1) == 0);
         cir.cancel();
     }
   

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinRandomSkinTexture.java
@@ -3,7 +3,6 @@
 package com.microsoft.Malmo.Mixins;
 
 
-import java.util.Random;
 import java.util.UUID;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,10 +10,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.microsoft.Malmo.MalmoMod;
 import com.microsoft.Malmo.Utils.SeedHelper;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.DefaultPlayerSkin;
 
 

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/SeedHelper.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/SeedHelper.java
@@ -19,26 +19,23 @@
 
 package com.microsoft.Malmo.Utils;
 
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.item.Item;
-import net.minecraft.server.MinecraftServer;
-import net.minecraftforge.common.config.Configuration;
-import net.minecraftforge.event.world.WorldEvent;
-import net.minecraftforge.fml.common.FMLCommonHandler;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
 
 import com.microsoft.Malmo.MalmoMod;
 import com.microsoft.Malmo.MalmoMod.IMalmoMessageListener;
 import com.microsoft.Malmo.MalmoMod.MalmoMessageType;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.Item;
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 
 @Mod.EventBusSubscriber
 public class SeedHelper implements IMalmoMessageListener

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/SeedHelper.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/SeedHelper.java
@@ -19,26 +19,45 @@
 
 package com.microsoft.Malmo.Utils;
 
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
+import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 
 import com.microsoft.Malmo.MalmoMod;
+import com.microsoft.Malmo.MalmoMod.IMalmoMessageListener;
+import com.microsoft.Malmo.MalmoMod.MalmoMessageType;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
 @Mod.EventBusSubscriber
-public class SeedHelper
+public class SeedHelper implements IMalmoMessageListener
 {
     private static ArrayDeque<Long> seeds = new ArrayDeque<Long>();
     private static Long currentSeed;
     private static HashMap<String, Random> specificSeedGenerators = new HashMap<String, Random>();
     private static int numRandoms = 0;
+
+    public static Integer mapSeed;
+
+    // The pseudo-random number that is shared across all players
+    private static long worldSeed = new Random().nextLong();
+
+    public static SeedHelper instance = new SeedHelper();
+
+    public SeedHelper() {
+        MalmoMod.MalmoMessageHandler.registerForMessage(this, MalmoMessageType.SERVER_COMMON_SEED);
+    }
 
     /** Initialize seeding. */
     static public void update(Configuration configs)
@@ -82,9 +101,20 @@ public class SeedHelper
 
     @SubscribeEvent
     public static void onWorldCreate(WorldEvent.Load loadEvent){
+
         loadEvent.getWorld().rand = getRandom(loadEvent.getWorld().toString());
     }
 
+    @SubscribeEvent
+    public static void onPlayerLogin(PlayerLoggedInEvent event) {
+        // MalmoMod.safeSendToAll(MalmoMessageType.SERVER_COMMON_SEED,
+        // Collections.singletonMap("commonSeed", String.valueOf(worldSeed)));
+        MalmoMod.network.sendTo(
+                new MalmoMod.MalmoMessage(MalmoMessageType.SERVER_COMMON_SEED, 0,
+                        Collections.singletonMap("commonSeed", String.valueOf(worldSeed))),
+                (EntityPlayerMP) event.player);
+
+    }
 
     public static void forceUpdateMinecraftRandoms(){
         Item.itemRand = getRandom("item");
@@ -116,5 +146,16 @@ public class SeedHelper
             }
         }
         return true;
+    }
+
+    @Override
+    public void onMessage(MalmoMessageType messageType, Map<String, String> data) {
+        if (messageType == MalmoMessageType.SERVER_COMMON_SEED) {
+            worldSeed = Long.valueOf(data.get("commonSeed"));
+        }
+    }
+
+    public static long getWorldSeed() {
+        return worldSeed;
     }
 }

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/SeedHelper.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/SeedHelper.java
@@ -104,8 +104,6 @@ public class SeedHelper implements IMalmoMessageListener
 
     @SubscribeEvent
     public static void onPlayerLogin(PlayerLoggedInEvent event) {
-        // MalmoMod.safeSendToAll(MalmoMessageType.SERVER_COMMON_SEED,
-        // Collections.singletonMap("commonSeed", String.valueOf(worldSeed)));
         MalmoMod.network.sendTo(
                 new MalmoMod.MalmoMessage(MalmoMessageType.SERVER_COMMON_SEED, 0,
                         Collections.singletonMap("commonSeed", String.valueOf(worldSeed))),


### PR DESCRIPTION
The function "isSlimSkin" is actually being called more than once (I assume every time client decides it needs to render the other player?). Because we are currently using a random boolean as a result, the agent "blinks" between two skins (alex and steve) - can be reproduced in interactive mode with 2 agents. 
This fix chooses the random number once and adds it to the UUID when deciding which skin to use. It fixes blinking, however, when there are more than 2 agents, the results are not consistent between the observers.