### PR TITLE
Fix multiagent crashes

### DIFF
--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoEnvServer.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoEnvServer.java
@@ -476,8 +476,8 @@ public class MalmoEnvServer implements IWantToQuit {
             profiler.endSection(); //cmd
             profiler.startSection("clientTick");
 
-            // TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> Received: " + actions);
-            // TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> Requesting tick. Should use previous env state: " + Boolean.toString(shouldUsePreviousEnvState));
+            TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> Received: " + actions);
+            TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> Requesting tick. Should use previous env state: " + Boolean.toString(shouldUsePreviousEnvState));
             // Now wait to run a tick
 
             // If synchronous mode is off then we should see if want to quit is true.

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoEnvServer.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoEnvServer.java
@@ -89,6 +89,9 @@ public class MalmoEnvServer implements IWantToQuit {
     private Condition cond = lock.newCondition();
 
     private EnvState envState = new EnvState();
+    private EnvState previousEnvState = null;
+
+    private boolean shouldUsePreviousEnvState = false;
 
     private Hashtable<String, Integer> initTokens = new Hashtable<String, Integer>();
 
@@ -474,13 +477,18 @@ public class MalmoEnvServer implements IWantToQuit {
             profiler.startSection("clientTick");
 
             // TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> Received: " + actions);
-            // TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> Requesting tick.");
+            // TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> Requesting tick. Should use previous env state: " + Boolean.toString(shouldUsePreviousEnvState));
             // Now wait to run a tick
 
             // If synchronous mode is off then we should see if want to quit is true.
             if(!done) 
                 TimeHelper.SyncManager.clientTick.requestAndWait();
 
+            if (shouldUsePreviousEnvState && previousEnvState != null) {
+                envState = previousEnvState;
+                envState.done = true;
+            }
+            shouldUsePreviousEnvState = false;
 
             // TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> TICK DONE.  Getting observation.");
             profiler.endSection();
@@ -500,7 +508,7 @@ public class MalmoEnvServer implements IWantToQuit {
                 // if(info == null)
                 // TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> FILLING INFO: NULL");
                 // else
-                // TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> FILLING " + info.toString());
+                // TimeHelper.SyncManager.debugLog("[MALMO_ENV_SERVER] <STEP> FILLING NONNULL");
 
             }
             done = envState.done;
@@ -511,6 +519,23 @@ public class MalmoEnvServer implements IWantToQuit {
             if (done) {
                 TimeHelper.SyncManager.setSynchronous(false);
             }
+
+            previousEnvState = new EnvState();
+            previousEnvState.reward = envState.reward;
+            previousEnvState.commands = envState.commands;
+            previousEnvState.obs = envState.obs;
+            previousEnvState.info = envState.info;
+            previousEnvState.missionInit = envState.missionInit;
+            previousEnvState.done = envState.done;
+            previousEnvState.running = envState.running;
+            previousEnvState.quit = envState.quit;
+            previousEnvState.token = envState.token;
+            previousEnvState.experimentId = envState.experimentId;
+            previousEnvState.agentCount = envState.agentCount;
+            previousEnvState.reset = envState.reset;
+            previousEnvState.synchronous = envState.synchronous;
+            previousEnvState.seed = envState.seed;
+
 
             envState.info = "{}";
             envState.obs = null;
@@ -888,6 +913,11 @@ public class MalmoEnvServer implements IWantToQuit {
     public void setRunning(boolean running) {
         envState.running = false;
     }
+
+    public void usePreviousState() {
+        shouldUsePreviousEnvState = true;
+    }
+
     // Record a Malmo "observation" json - as the env info since an environment "obs" is a video frame.
     public void observation(String info) {
         // Parsing obs as JSON would be slower but less fragile than extracting the turn_key using string search.

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
@@ -594,6 +594,7 @@ public class ServerStateMachine extends StateMachine
     public class WaitingForAgentsToQuitEpisode extends ErrorAwareEpisode implements MalmoMod.IMalmoMessageListener
     {
         private HashMap<String, Boolean> agentsStopped = new HashMap<String, Boolean>();
+        private Map<String, String> data = null;
 
         protected WaitingForAgentsToQuitEpisode(ServerStateMachine machine)
         {
@@ -610,7 +611,7 @@ public class ServerStateMachine extends StateMachine
                 this.agentsStopped.put(as.getName(), false);
 
             // Now tell all the agents to stop what they are doing:
-            Map<String, String>data = new HashMap<String, String>();
+            data = new HashMap<String, String>();
             data.put("QuitCode", ServerStateMachine.this.quitCode);
             MalmoMod.safeSendToAll(MalmoMessageType.SERVER_STOPAGENTS, data);
         }
@@ -649,6 +650,9 @@ public class ServerStateMachine extends StateMachine
                 // to tell us it's finished its mission.
                 MalmoMod.safeSendToAll(MalmoMessageType.SERVER_ABORT);
                 episodeHasCompleted(ServerState.ERROR);
+            }
+            if (data != null) {
+                MalmoMod.safeSendToAll(MalmoMessageType.SERVER_STOPAGENTS, data);
             }
         }
     }

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/StateMachine.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/StateMachine.java
@@ -20,7 +20,6 @@
 package com.microsoft.Malmo;
 
 import java.util.ArrayList;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;

--- a/minerl/env/_multiagent.py
+++ b/minerl/env/_multiagent.py
@@ -326,10 +326,10 @@ class _MultiAgentEnv(gym.Env):
                         "the info dictionary returned by the step function."
                     )
                     return (
-                        self.observation_space.sample(),
-                        0,
+                        {agent: self.observation_space.sample() for agent in actions},
+                        {agent: 0 for agent in actions},
                         self.done,
-                        {"error": "Connection timed out!"},
+                        {agent: {"error": "Connection timed out!"} for agent in actions},
                     )
 
             # this will currently only consider the env done when all agents report done individually

--- a/minerl/env/malmo.py
+++ b/minerl/env/malmo.py
@@ -446,7 +446,7 @@ class MinecraftInstance(object):
                     "Tried to launch Minecraft on port {} but that port was taken, instead Minecraft is using port {}.".format(
                         port, self.port))
 
-            # supress entire output, otherwise the subprocess will block
+            # suppress entire output, otherwise the subprocess will block
             # NB! there will be still logs under Malmo/Minecraft/run/logs
             # FNULL = open(os.devnull, 'w')
             # launch a logger process


### PR DESCRIPTION
Fix crashes in Minecraft due to three issues:
    - Loss of connection from the client to the server weren't handled properly. Now makes it so that the client uses its old data when the connection is lost instead of crashing.
    - A race condition between the client going idle and the server asking the clients to stop. Now the server repeatedly asks the client to stop in case the message was lost.
    - When one of the client dies, it tries to trigger end of episode. This is bad for multiagent because we might want to keep the episode going and also it seemed to cause issues with the clients getting desynchronized (one thinks the episode has ended, the other does not), causing crashes. Now we don't end episodes on the Java side if a client dies and we are in multiagent.