### PR TITLE
.gitignore: env/ => /env/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,13 +179,13 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
+/.env
+/.venv
+/env/
+/venv/
+/ENV/
+/env.bak/
+/venv.bak/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
Prepend `/` to python environment directories in `.gitignore`. (Change made because new files added to `minerl/env/*.py` in our fork were auto-ignored by the current gitignore settings)