### PR TITLE
make it possible to tell which agent is which in create agent start

### DIFF
--- a/minerl/herobraine/env_spec.py
+++ b/minerl/herobraine/env_spec.py
@@ -53,7 +53,9 @@ class EnvSpec(abc.ABC):
 
         # after create_server_world_generators(), because it will see python generated map
         # to pick a good location
-        self.agent_start = [self.create_agent_start() for _ in range(self.agent_count)]
+        self.agent_start = []
+        for self.current_agent in range(self.agent_count):
+            self.agent_start.append(self.create_agent_start())
 
         # check that the observables (list) have no duplicate to_strings
         assert len([o.to_string() for o in self.observables]) == len(set([o.to_string() for o in self.observables]))


### PR DESCRIPTION
The method is a bit hacky (creating a stateful attribute to contain which agent is being processed), but I thought doing it this way would make it possible to not break existing code, vs adding a new argument to that function that is inherited all over the place.