### PR TITLE
Env spec autoblacklist

### DIFF
--- a/minerl/data/pipeline/publish.py
+++ b/minerl/data/pipeline/publish.py
@@ -352,19 +352,6 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
                 raise e
 
 
-            # All Envs auto-blacklist by default if
-            # if action${attack,forward} exist and are never used.
-            # if reward is 0
-            #
-            #
-            # "Obtain" EnvSpecs also auto-blacklist if reward is less than 64.
-            #
-            # non-"Obtain", non-"SimonSays" environments auto-blacklist if reward == 1024.
-            #
-            # Survival EnvSpecs never blacklist.
-            # Obfuscated EnvSpecs never blacklist.
-            # Do these even get processed by the pipeline?
-
             reason = env_spec.auto_blacklist_demo(published)
             if reason is not None:
                 assert len(reason) > 0, "reason needs to be non-empty str or None"

--- a/minerl/data/pipeline/publish.py
+++ b/minerl/data/pipeline/publish.py
@@ -255,7 +255,8 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
         universal = remove_initial_frames(universal)
 
         for env_spec in filtered_environments:
-            dest_folder = J(output_root, env_spec.name, 'v{}_{}'.format(PUBLISHER_VERSION, segment_str))
+            dest_folder = J(output_root, env_spec.name, 'v{}_{}'
+                            .format(PUBLISHER_VERSION, segment_str))
             recording_dest = J(dest_folder, 'recording.mp4')
             rendered_dest = J(dest_folder, 'rendered.npz')
             metadata_dest = J(dest_folder, 'metadata.json')
@@ -271,7 +272,8 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
             env_spec.reset()
 
             # Load relevant handlers
-            info_handlers = [obs for obs in env_spec.observables if not isinstance(obs, handlers.POVObservation)]
+            info_handlers = [obs for obs in env_spec.observables
+                             if not isinstance(obs, handlers.POVObservation)]
             reward_handlers = env_spec.rewardables
             # TODO (R): Support done handlers.
             # done_handlers = [hdl for hdl in task.create_mission_handlers() if isinstance(hdl, handlers.QuitHandler)]
@@ -351,7 +353,6 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
                         continue
                 raise e
 
-
             reason = env_spec.auto_blacklist_demo(published)
             if reason is not None:
                 assert len(reason) > 0, "reason needs to be non-empty str or None"
@@ -377,12 +378,14 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
                 with open(metadata_source, 'r') as meta_file:
                     source = json.load(meta_file)
                     metadata_out = {}
-                    metadata_out['success'] = bool(env_spec.determine_success_from_rewards(published['reward']))
+                    metadata_out['success'] = bool(
+                        env_spec.determine_success_from_rewards(published['reward']))
                     metadata_out['duration_ms'] = len(
                         published['reward']) * 50  # source['end_time'] - source['start_time']
                     metadata_out['duration_steps'] = len(published['reward'])
                     metadata_out['total_reward'] = sum(published['reward'])
-                    metadata_out['stream_name'] = 'v{}{}'.format(PUBLISHER_VERSION, recording_dir[len('g1'):])
+                    metadata_out['stream_name'] = 'v{}{}'.format(
+                        PUBLISHER_VERSION, recording_dir[len('g1'):])
                     metadata_out['true_video_frame_count'] = calculate_frame_count(recording_dest)
                     with open(metadata_dest, 'w') as meta_file_out:
                         json.dump(metadata_out, meta_file_out)

--- a/minerl/data/pipeline/publish.py
+++ b/minerl/data/pipeline/publish.py
@@ -310,7 +310,8 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
                         # Perhaps we can wrap here
                         if isinstance(env_spec, EnvWrapper):
                             if _prefix == OBSERVABLE_KEY:
-                                tick_data[_prefix]['pov'] = env_spec.observation_space['pov'].no_op()
+                                tick_data[_prefix]['pov'] = (
+                                    env_spec.observation_space['pov'].no_op())
                                 tick_data[_prefix] = env_spec.wrap_observation(tick_data[_prefix])
                                 del tick_data[_prefix]['pov']
                             elif _prefix == ACTIONABLE_KEY:

--- a/minerl/data/pipeline/publish.py
+++ b/minerl/data/pipeline/publish.py
@@ -254,8 +254,8 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
 
         universal = remove_initial_frames(universal)
 
-        for environment in filtered_environments:
-            dest_folder = J(output_root, environment.name, 'v{}_{}'.format(PUBLISHER_VERSION, segment_str))
+        for env_spec in filtered_environments:
+            dest_folder = J(output_root, env_spec.name, 'v{}_{}'.format(PUBLISHER_VERSION, segment_str))
             recording_dest = J(dest_folder, 'recording.mp4')
             rendered_dest = J(dest_folder, 'rendered.npz')
             metadata_dest = J(dest_folder, 'metadata.json')
@@ -268,15 +268,15 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
             if E(rendered_dest):
                 continue
 
-            environment.reset()
+            env_spec.reset()
 
             # Load relevant handlers
-            info_handlers = [obs for obs in environment.observables if not isinstance(obs, handlers.POVObservation)]
-            reward_handlers = environment.rewardables
+            info_handlers = [obs for obs in env_spec.observables if not isinstance(obs, handlers.POVObservation)]
+            reward_handlers = env_spec.rewardables
             # TODO (R): Support done handlers.
             # done_handlers = [hdl for hdl in task.create_mission_handlers() if isinstance(hdl, handlers.QuitHandler)]
-            action_handlers = environment.actionables
-            monitor_handlers = environment.monitors
+            action_handlers = env_spec.actionables
+            monitor_handlers = env_spec.monitors
 
             all_handlers = [hdl for sublist in [info_handlers, reward_handlers, action_handlers] for hdl in sublist]
 
@@ -306,13 +306,13 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
                             tick_data[_prefix][handler.to_string()] = val
 
                         # Perhaps we can wrap here
-                        if isinstance(environment, EnvWrapper):
+                        if isinstance(env_spec, EnvWrapper):
                             if _prefix == OBSERVABLE_KEY:
-                                tick_data[_prefix]['pov'] = environment.observation_space['pov'].no_op()
-                                tick_data[_prefix] = environment.wrap_observation(tick_data[_prefix])
+                                tick_data[_prefix]['pov'] = env_spec.observation_space['pov'].no_op()
+                                tick_data[_prefix] = env_spec.wrap_observation(tick_data[_prefix])
                                 del tick_data[_prefix]['pov']
                             elif _prefix == ACTIONABLE_KEY:
-                                tick_data[_prefix] = environment.wrap_action(tick_data[_prefix])
+                                tick_data[_prefix] = env_spec.wrap_action(tick_data[_prefix])
 
                     tick_data = flatten(tick_data, sep=HANDLER_TYPE_SEPERATOR)
                     for k, v in tick_data.items():
@@ -327,7 +327,7 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
                         published[k] = published[k][1:]
 
             except NotImplementedError as err:
-                print('Exception:', str(err), 'found with environment:', environment.name)
+                print('Exception:', str(err), 'found with environment:', env_spec.name)
                 raise err
             except KeyError as err:
                 print("Key error in file - check from_universal for handlers")
@@ -351,18 +351,26 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
                         continue
                 raise e
 
-            # Don't release ones with 1024 reward (they are bad streams) and other smoke-tests
-            if 'Survival' not in environment.name and not isinstance(environment, Obfuscated):
-                # TODO these could be handlers instead!
-                if sum(published['reward']) == 1024.0 and 'Obtain' in environment.name \
-                        and ('SimonSays' not in environment.name) \
-                        or sum(published['reward']) < 64 and ('Obtain' not in environment.name) \
-                        or sum(published['reward']) == 0.0 \
-                        or sum(published['action$forward']) == 0 \
-                        or sum(published['action$attack']) == 0 and 'Navigate' not in environment.name:
-                    black_list.add(segment_str)
-                    print('Hey we should have blacklisted {} tyvm'.format(segment_str))
-                    return 0
+
+            # All Envs auto-blacklist by default if
+            # if action${attack,forward} exist and are never used.
+            # if reward is 0
+            #
+            #
+            # "Obtain" EnvSpecs also auto-blacklist if reward is less than 64.
+            #
+            # non-"Obtain", non-"SimonSays" environments auto-blacklist if reward == 1024.
+            #
+            # Survival EnvSpecs never blacklist.
+            # Obfuscated EnvSpecs never blacklist.
+            # Do these even get processed by the pipeline?
+
+            reason = env_spec.auto_blacklist_demo(published)
+            if reason is not None:
+                assert len(reason) > 0, "reason needs to be non-empty str or None"
+                print(f"Blacklisting {env_spec.name} demonstration {segment_str}")
+                black_list.add(segment_str)
+                return 0
 
             # Setup destination root
             if not E(dest_folder):
@@ -382,7 +390,7 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
                 with open(metadata_source, 'r') as meta_file:
                     source = json.load(meta_file)
                     metadata_out = {}
-                    metadata_out['success'] = bool(environment.determine_success_from_rewards(published['reward']))
+                    metadata_out['success'] = bool(env_spec.determine_success_from_rewards(published['reward']))
                     metadata_out['duration_ms'] = len(
                         published['reward']) * 50  # source['end_time'] - source['start_time']
                     metadata_out['duration_steps'] = len(published['reward'])

--- a/minerl/herobraine/env_spec.py
+++ b/minerl/herobraine/env_spec.py
@@ -7,7 +7,7 @@ from minerl.herobraine.hero.handlers.translation import TranslationHandler
 import typing
 from minerl.herobraine.hero.spaces import Dict
 from minerl.herobraine.hero.handler import Handler
-from typing import List
+from typing import List, Optional
 
 import jinja2
 import gym
@@ -280,7 +280,7 @@ class EnvSpec(abc.ABC):
 
         Deduplication happens by first getting all of the handler.xml() strings
         of the handlers, and then converting them into etrees. After that we check
-        if the there are any top level elements that are duplicated and pick the first of them
+        if there are any top level elements that are duplicated and pick the first of them
         to retain. We then convert the remaining etrees back into strings and join them with new lines.
 
         Args:
@@ -300,3 +300,39 @@ class EnvSpec(abc.ABC):
 
         return [etree.tostring(t, pretty_print=True).decode('utf-8')
                 for t in consolidated_trees]
+
+    def auto_blacklist_demo(self, npz_data: dict) -> Optional[str]:
+        """Return a non-empty str if `publish.py` should blacklist a demonstration.
+
+        We can't catch all cases of bad demonstrations automatically, but overriding this
+        method can allow for some quick, automatic filtering.
+
+        Args:
+            npz_data: A dict of numpy values from this demonstration about to be saved
+            as "rendered.npz" by the publish.py stage of the dataset pipeline.
+
+        Returns:
+            Either None, or a nonempty str describing why this demonstration should be
+            blacklisted.
+        """
+        if 'Survival' not in self.name:
+            return None
+
+        # Various smoke-tests.
+        ep_return = sum(npz_data['reward'])
+        if ep_return == 1024.0 and 'Obtain' in self.name and 'SimonSays' not in self.name:
+            return f"ep_return={ep_return} in non-Obtain/SimonSays env was unexpectedly 1024"
+
+        if ep_return < 64 and ('Obtain' not in self.name):
+            return f"ep_return={ep_return} in non-Obtain env was unexpectedly low (<64)"
+
+        if ep_return == 0.0:
+            return "zero reward"
+
+        if sum(npz_data['action$forward']) == 0:
+            return "no forward movement"
+
+        if sum(npz_data['action$attack']) == 0 and 'Navigate' not in self.name:
+            return "no attack action on non-Navigate env"
+
+        return None

--- a/minerl/herobraine/env_spec.py
+++ b/minerl/herobraine/env_spec.py
@@ -321,7 +321,7 @@ class EnvSpec(abc.ABC):
         # Various smoke-tests.
         ep_return = sum(npz_data['reward'])
         if ep_return == 1024.0 and 'Obtain' in self.name and 'SimonSays' not in self.name:
-            return f"ep_return={ep_return} in non-Obtain/SimonSays env was unexpectedly 1024"
+            return f"ep_return={ep_return} in non-SimonSays Obtain env was unexpectedly 1024"
 
         if ep_return < 64 and ('Obtain' not in self.name):
             return f"ep_return={ep_return} in non-Obtain env was unexpectedly low (<64)"

--- a/minerl/herobraine/env_specs/obtain_specs.py
+++ b/minerl/herobraine/env_specs/obtain_specs.py
@@ -7,7 +7,7 @@ from minerl.herobraine.hero.mc import MS_PER_STEP, STEPS_PER_MS
 from minerl.herobraine.env_specs.simple_embodiment import SimpleEmbodimentEnvSpec
 from minerl.herobraine.hero.handler import Handler
 from minerl.herobraine.hero import handlers
-from typing import List, Union, Dict
+from typing import Dict, List, Optional, Union
 from gym import spaces
 
 none = 'none'

--- a/minerl/herobraine/env_specs/survival_specs.py
+++ b/minerl/herobraine/env_specs/survival_specs.py
@@ -2,7 +2,7 @@
 # Author: William H. Guss, Brandon Houghton
 from minerl.herobraine.env_specs.simple_embodiment import SimpleEmbodimentEnvSpec
 from minerl.herobraine.hero.handler import Handler
-from typing import List
+from typing import List, Optional
 
 import gym
 

--- a/minerl/herobraine/wrappers/obfuscation_wrapper.py
+++ b/minerl/herobraine/wrappers/obfuscation_wrapper.py
@@ -2,7 +2,7 @@
 # Author: William H. Guss, Brandon Houghton
 
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 from collections import OrderedDict
@@ -137,3 +137,7 @@ class Obfuscated(EnvWrapper):
     def get_docstring(self):
         # TODO fix this
         return super().get_docstring()
+
+    def auto_blacklist_demo(self, demo_npz_data: dict) -> Optional[str]:
+        # Obfuscated demonstrations are never blacklisted.
+        return None


### PR DESCRIPTION
Adds `EnvSpec.auto_blacklist_demo` method and refactors publish.py blacklisting logic.

Summary of existing smoke test logic in `publish.py`:
 * Survival and Obfuscated EnvSpecs never blacklist.
 * "Obtain" environments auto-blacklist if reward == 1024 (excluding "SimonSays").
 * if forward action is never used, then auto-blacklist.
 * if attack action is never used, then auto-blacklist unless this is a "Navigate" demonstration.
 * if reward is 0, then auto-blacklist.

It seemed like the most straightforward way to refactor this logic in `publish.py` is to have `Obfuscated.auto_blacklist_demo` never blacklist (there is no analogous `EnvSpec` base class for "Survival" data right now), and the base class `EnvSpec` contain the rest of the logic. 

BASALT env specs will have an `auto_blacklist_demo` like this: https://gist.github.com/shwang/eb9bcf001d90836800d0c6f755b0b1cf