### PR TITLE
v0.3.7 (hotfixes for pypi)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "minerl/env/Malmo"]
 	path = minerl/env/Malmo
 	url = https://github.com/cmu-rl/Malmo.git
+	branch = minerl

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ def package_files(directory):
             and not "Malmo/MalmoEnv" in path
             and not "Malmo/ALE_ROMS" in path
             and not "Malmo/scripts" in path):
-            
+
             paths.append((path, [os.path.join(path, f) for f in filenames if not isdir(f)]))
 
     return paths
@@ -84,11 +84,12 @@ data_files = []
 data_files += package_files('minerl/env/missions')
 data_files += package_files('minerl/herobraine/env_specs')
 data_files += package_files('minerl/data/assets')
+data_files += package_files('minerl/env/Malmo')
 
 
 setuptools.setup(
       name='minerl',
-      version='0.3.6',
+      version='0.3.7',
       description='MineRL environment and data loader for reinforcement learning from human demonstration in Minecraft',
       long_description=markdown,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Updating `master` for next pypi release that includes all nifty fixes currently in `master` + the HTTPS repo fix + fixing building wheel package.

Building wheel and installing tested to work on Windows 10 and Ubuntu 20.04 (`python3 setup.py sdist; pip3 install dist/minerl-0.3.7.tar.gz`)

If you are pulling this to existing directory (not full clone), you need to sync submodules
```
git submodule sync
git submodule update --init --remote
```

