### PR TITLE
Minimal fixes for Windows

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include README.md
 include requirements.txt
 include LICENSE
-recursive-include minerl/herobraine/env_specs/ *
+recursive-include minerl/herobraine/env_specs *
 include minerl/herobraine/hero/mc_constants.json
 include minerl/herobraine/hero/mission.xml.j2
 include minerl/env/info.npz

--- a/minerl/Malmo/Minecraft/gradlew.bat
+++ b/minerl/Malmo/Minecraft/gradlew.bat
@@ -72,7 +72,7 @@ set CMD_LINE_ARGS=%$
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS% --no-daemon
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/minerl/Malmo/Minecraft/gradlew.bat
+++ b/minerl/Malmo/Minecraft/gradlew.bat
@@ -72,7 +72,7 @@ set CMD_LINE_ARGS=%$
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS% --no-daemon
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/TimeHelper.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/TimeHelper.java
@@ -52,7 +52,7 @@ public class TimeHelper
     public static long displayGranularityMs = 50;  // How quickly we allow the Minecraft window to update.
     private static long lastUpdateTimeMs;
     public static int frameSkip = 1; // Note: Not fully implemented
-
+    public static Boolean isWindows = System.getProperty("os.name").startsWith("Windows");
 
     static public class FlushableStateMachine {
         // We should really just use locks.
@@ -314,7 +314,14 @@ public class TimeHelper
         if(lastUpdateTimeMs == -1)
             lastUpdateTimeMs = timeNow;
         
-        if (timeNow - lastUpdateTimeMs > displayGranularityMs)
+        // Do not update display on Windows at all.
+        // Doing so will reset the observation data we get (camera is zeros),
+        // and also blinks the Minecraft window between visible frame and black image.
+
+        // This has the side-effect of Minecraft window being blank and
+        // reported as "not responding".
+        // TODO what is the real cause behind the issues
+        if (!isWindows && timeNow - lastUpdateTimeMs > displayGranularityMs)
         {
             Minecraft.getMinecraft().updateDisplay();
             lastUpdateTimeMs = timeNow;

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ psutil>=5.6.2
 Pyro4>=4.76
 getch>=1.0; sys_platform != 'win32' and sys_platform != 'cygwin'
 coloredlogs>=10.0
-matplotlib==3.0.3
+pillow>=8.0.0
+matplotlib>=3.2.2
 dill>=0.3.1.1
 daemoniker>=0.2.3
 xmltodict==0.12.0


### PR DESCRIPTION
Minimal fixes to get MineRL running on Windows 10 with some caveats. Tested Python 3.7 and 3.9 to work.

Gotchas (@brandonhoughton please sanity check):
- Multiple instances does not work (the gradle.build trick with "dummy_value" does not work with current Gradle version). Building is fixed with "--no-daemon" flag, which makes building slower (thanks, builtin anti-virus checking every tiny thing...)
- Minecraft window stays blank white. Doing `updateDisplay()` does show image frame, but it also zeros-out the observation buffer