### PR TITLE
publish: Actually print out blacklist reason

### DIFF
--- a/minerl/data/pipeline/publish.py
+++ b/minerl/data/pipeline/publish.py
@@ -364,7 +364,9 @@ def render_data(output_root, recording_dir, experiment_folder, black_list, lineN
             reason = env_spec.get_blacklist_reason(published)
             if reason is not None:
                 assert len(reason) > 0, "reason needs to be non-empty str or None"
-                print(f"Blacklisting {env_spec.name} demonstration {segment_str}")
+                print(f"Blacklisting {env_spec.name} demonstration {segment_str} "
+                      f"because: '{reason}'."
+                      )
                 black_list.add(segment_str)
                 return 0
 


### PR DESCRIPTION
Didn't actually print out the reason (e.g. "no snowball thrown") prior to this commit