### PR TITLE
pipeline: Fix failing publish due to hardcoded version

### DIFF
--- a/minerl/data/pipeline/pipeline.py
+++ b/minerl/data/pipeline/pipeline.py
@@ -23,6 +23,7 @@ from typing import Mapping, Optional, Sequence
 
 import bullet
 
+from minerl import data
 from minerl.data.pipeline import download2, generate, make_minecrafts, merge, publish, render
 
 
@@ -76,7 +77,7 @@ def _publish_generate_version_file():
     path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(path, "w") as f:
-        f.write("4")
+        f.write(str(data.DATA_VERSION))
     print(f"Wrote to {path}.")
 
 


### PR DESCRIPTION
A recent change switched minerl.data.DATA_VERSION from 4 to 3. This caused publish.py to fail or include the wrong data version inside its S3-ready tar files.

This PR causes pipeline.py to generate the (required for running publish.py) ~/minerl.data/output/data/VERSION file using a non-hardcoded value to avoid this failure.