### PR TITLE
herobraine..action: Fix deprecation collections warning

### DIFF
--- a/minerl/env/_singleagent.py
+++ b/minerl/env/_singleagent.py
@@ -4,7 +4,6 @@
 
 from typing import Any, Dict, Tuple
 from minerl.env._multiagent import _MultiAgentEnv
-from collections import Iterable
 
 
 class _SingleAgentEnv(_MultiAgentEnv):

--- a/minerl/herobraine/hero/handlers/agent/action.py
+++ b/minerl/herobraine/hero/handlers/agent/action.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2020 All Rights Reserved
 # Author: William H. Guss, Brandon Houghton
+from collections.abc import Iterable
 import typing
-from typing import Any, List, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 from minerl.herobraine.hero import spaces
 from minerl.herobraine.hero.handlers.translation import TranslationHandler
-
-from collections import Iterable
 
 from minerl.herobraine.hero.handlers import util
 


### PR DESCRIPTION
```
minerl/herobraine/hero/handlers/agent/action.py:10
  /home/steven/PycharmProjects/minerl-3/minerl/herobraine/hero/handlers/agent/action.py:10:
DeprecationWarning: Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated since Python 3.3,and in
3.9 it will stop working
    from collections import Iterable
```
