### PR TITLE
MineRLEnv: Set MINERL_DEBUG_LOG=1 for Malmo logs

### DIFF
--- a/minerl/env/malmo.py
+++ b/minerl/env/malmo.py
@@ -461,6 +461,10 @@ class MinecraftInstance(object):
                 mine_log_encoding = locale.getpreferredencoding(False)
                 line = self.minecraft_process.stdout.readline().decode(mine_log_encoding)
 
+                if os.environ.get("MINERL_DEBUG_LOG", False):
+                    # Print Java logs to console
+                    print(line.strip("\n"))
+
                 # Check for failures and print useful messages!
                 _check_for_launch_errors(line)
 
@@ -528,6 +532,11 @@ class MinecraftInstance(object):
                             mine_log_encoding = locale.getpreferredencoding(False)
                             logger.error("UnicodeDecodeError, switching to default encoding")
                             linestr = line.decode(mine_log_encoding)
+
+                        if os.environ.get("MINERL_DEBUG_LOG", False):
+                            # Print Java logs to console
+                            print(linestr.strip("\n"))
+
                         linestr = "\n".join(linestr.split("\n")[:-1])
                         # some heuristics to figure out which messages
                         # need to be elevated in logging level


### PR DESCRIPTION
Much easier to set this env variable and read stdout rather than
search for the corresponding log file. Used to debug Malmo XML
issue in #515.
