### PR TITLE
tests: Use filelock on @pytest.mark.serial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -289,3 +288,7 @@ minerl/Malmo/Minecraft/*.launch
 caches/
 native/
 wrapper/
+
+
+# Pytest artifacts
+tests/*.lock

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,5 @@ norecursedirs = */Malmo */dependencies tests/local */excluded build dist *.egg* 
 # Add these directories to Python's path for importing
 python_paths = ./
 setenv = MINERL_TESTING=1
+markers =
+    serial: Run this test serially via filelock.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ inflection>=0.3.1
 jinja2>=2.11.2
 simple-term-menu
 bullet
+filelock

--- a/scripts/test_build_deploy.sh
+++ b/scripts/test_build_deploy.sh
@@ -20,7 +20,8 @@ pip install .
 # Copy data to the ci machines if needed for tests
 #az storage copy -s $AZ_MINERL_DATA -d $MINERL_DATA_ROOT --recursive --subscription sci
 
-pytest . -n 1
+# Note tests that lauch Minecraft MUST be marked serial via the "@pytest.mark.serial" annotation
+pytest . -n 4
 pip uninstall -y minerl
 
 pip list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import filelock
+import pytest
+
+@pytest.fixture(autouse=True)
+def block_on_serial_mark(request):
+    """Use file lock to force sequential run of tests decorated with
+    `@pytest.mark.sequential` to avoid race-conditions with running tests in parallel.
+    """
+    # h/t: https://github.com/pytest-dev/pytest-xdist/issues/385#issuecomment-762670129
+
+    # XXX: Could also have different file locks grouped by different pytest marks.
+    #   IE using marker="sequential_{lock_group_name}"
+    if request.node.get_closest_marker("serial"):
+        with filelock.FileLock("tests/pytest_minerl_serial.lock"):
+            yield
+    else:
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import filelock
 import pytest
 
+
 @pytest.fixture(autouse=True)
 def block_on_serial_mark(request):
     """Use file lock to force sequential run of tests decorated with

--- a/tests/item_variants_integration_test.py
+++ b/tests/item_variants_integration_test.py
@@ -129,6 +129,7 @@ class TestVariantEnvs:
         spec.check_observation_space()
         spec.check_action_space()
 
+    @pytest.mark.serial
     def test_starting_inventory(self, spec):
         with spec.make() as env:
             obs = env.reset()
@@ -141,6 +142,7 @@ class TestVariantEnvs:
                 quantity = d["quantity"]
                 assert inv_obs[item_id] == quantity
 
+    @pytest.mark.serial
     def test_randomized_equips(self, spec):
         with spec.make() as env:
             env.reset()


### PR DESCRIPTION
I came across https://github.com/pytest-dev/pytest-xdist/issues/385#issuecomment-762670129 earlier -- this could allow us to use parallelized testing again maybe!

Another related solution is to have the test suite run all normal "not serial" pytests in parallel, but run the `pytest -m "serial"` tests in serial.