### PR TITLE
Fix SyntaxWarnings from use of 'is'/'is not' for literal checks

### DIFF
--- a/minerl/data/data_pipeline.py
+++ b/minerl/data/data_pipeline.py
@@ -134,7 +134,7 @@ class DataPipeline:
         x = list(target_space.spaces.items())
         target_space.spaces = collections.OrderedDict(
             sorted(x, key=lambda x:
-            x[0] if x[0] is not 'pov' else 'z')
+            x[0] if x[0] != 'pov' else 'z')
         )
 
         # Now we just need to slice the dict.

--- a/minerl/data/data_pipeline.py
+++ b/minerl/data/data_pipeline.py
@@ -134,7 +134,7 @@ class DataPipeline:
         x = list(target_space.spaces.items())
         target_space.spaces = collections.OrderedDict(
             sorted(x, key=lambda x:
-            x[0] if x[0] != 'pov' else 'z')
+                   x[0] if x[0] != 'pov' else 'z')
         )
 
         # Now we just need to slice the dict.

--- a/minerl/herobraine/env_specs/navigate_specs.py
+++ b/minerl/herobraine/env_specs/navigate_specs.py
@@ -143,7 +143,7 @@ The agent is given a sparse reward (+100 upon reaching the goal, at which point 
     else:
         navigate_text += "**This variant of the environment is sparse.**\n"
 
-    if top is "normal":
+    if top == "normal":
         navigate_text += "\nIn this environment, the agent spawns on a random survival map.\n"
         navigate_text = navigate_text.format(*["" for _ in range(4)])
     else:

--- a/minerl/herobraine/hero/handlers/agent/reward.py
+++ b/minerl/herobraine/hero/handlers/agent/reward.py
@@ -209,7 +209,7 @@ class RewardForTouchingBlockType(RewardHandler):
             for block in obs['touched_blocks']:
                 for bl in self.blocks:
                     if bl['type'] in block['name'] and (
-                            not self.fired[bl['type']] or bl['behaviour'] is not "onlyOnce"):
+                            not self.fired[bl['type']] or bl['behaviour'] != "onlyOnce"):
                         reward += bl['reward']
                         self.fired[bl['type']] = True
 


### PR DESCRIPTION
When trying to use MineRL with Python 3.9, I get:

```
>>> import minerl
minerl/minerl/data/data_pipeline.py:137: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  x[0] if x[0] is not 'pov' else 'z')
minerl/minerl/herobraine/hero/handlers/agent/reward.py:212: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  not self.fired[bl['type']] or bl['behaviour'] is not "onlyOnce"):
minerl/minerl/herobraine/env_specs/navigate_specs.py:146: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if top is "normal":
```

This PR replaces `is` with `==` and `is not` with `!=`.

I've tested by installing `minerl` from my branch, and confirming that I can `import minerl` without issue.

Thanks!