### PR TITLE
Download script documentation and sanity checks

### DIFF
--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -1,4 +1,4 @@
-.. _MineRL competition environments: http://minerl.io/docs/environments/index.html#competition-environments
+.. _environments:
 
 General Information
 ================================

--- a/docs/source/tutorials/data_sampling.rst
+++ b/docs/source/tutorials/data_sampling.rst
@@ -5,8 +5,6 @@
 Downloading and Sampling The Dataset
 ====================================
 
-.. _check out the environment documentation: http://minerl.io/docs/environments/index.html#competition-environments
-
 .. role:: python(code)
    :language: python
 
@@ -53,18 +51,23 @@ To download the minimal dataset into ``MINERL_DATA_ROOT``, run the command:
 .. note::
 
     The full dataset for a particular environment, or for a particular competition (Diamond or Basalt)
-    can be downloaded using the ``--experiment EXPERIMENT`` and ``--competition COMPETITION`` flags.
+    can be downloaded using the ``--environment ENV_NAME`` and ``--competition COMPETITION`` flags.
+
+    ``ENV_NAME`` is any Gym environment name from the
+    :ref:`documented environments <environments>`.
+
+    ``COMPETITION`` is ``basalt`` or ``diamond``.
+
     For more information, run ``python3 -m minerl.data.download --help``.
 
     As an example, to download the full dataset for "MineRLObtainDiamond-v0", you can run
 
     .. code-block:: bash
 
-        python3 -m minerl.data.download --experiment "MineRLObtainDiamond-v0"
+        python3 -m minerl.data.download --environment "MineRLObtainDiamond-v0"
 
 
 
-For a complete list of published experiments, `check out the environment documentation`_.
 
 
 Sampling the Dataset with :code:`batch_iter`

--- a/docs/source/tutorials/data_sampling.rst
+++ b/docs/source/tutorials/data_sampling.rst
@@ -1,11 +1,11 @@
 ..  admonition:: Solution
     :class: toggle
 
-===============================
-Sampling The Dataset
-===============================
+====================================
+Downloading and Sampling The Dataset
+====================================
 
-.. _checkout the environment documentation: http://minerl.io/docs/environments/index.html#competition-environments
+.. _check out the environment documentation: http://minerl.io/docs/environments/index.html#competition-environments
 
 .. role:: python(code)
    :language: python
@@ -13,40 +13,68 @@ Sampling The Dataset
 .. role:: bash(code)
    :language: bash
 
-Now that your agent can act in the environment, we should 
-show it how to leverage human demonstrations.
 
-To get started, let's ensure the data has been downloaded.
+Introduction
+============
+
+Now that your agent can act in the environment, we should show it how to leverage human
+demonstrations.
+
+To get started, let's download the minimal version of the dataset (two demonstrations from every
+environment). Since there are over 20 MineRL environments, this is still a sizeable download, at
+about 2 GB.
+
+Then we will sample a few state-action-reward-done tuples from the ``MineRLObtainDiamond-v0``
+dataset.
+
+
+Setting up environment variables
+================================
+
+The :code:`minerl` package uses the :code:`MINERL_DATA_ROOT` environment variable to locate the data
+directory. Please export :code:`MINERL_DATA_ROOT=/your/local/path/`.
+
+(Here are some tutorials on how to set environment variables on
+`Linux/Mac <https://phoenixnap.com/kb/linux-set-environment-variable>`_ and
+`Windows <https://support.shotgunsoftware.com/hc/en-us/articles/114094235653-Setting-global-environment-variables-on-Windows>`_
+computers.)
+
+
+Downloading the MineRL Dataset with :code:`minerl.data.download`
+================================================================
+
+To download the minimal dataset into ``MINERL_DATA_ROOT``, run the command:
 
 .. code-block:: bash
 
-    # Unix, Linux
-    $MINERL_DATA_ROOT="your/local/path" python3 -m minerl.data.download
-
-    # Windows
-    $env:MINERL_DATA_ROOT="your/local/path"; python3 -m minerl.data.download
+    python3 -m minerl.data.download
 
 
-Or we can simply download a single experiment
+.. note::
 
-.. code-block:: bash
+    The full dataset for a particular environment, or for a particular competition (Diamond or Basalt)
+    can be downloaded using the ``--experiment EXPERIMENT`` and ``--competition COMPETITION`` flags.
+    For more information, run ``python3 -m minerl.data.download --help``.
 
-    # Unix, Linux
-    $MINERL_DATA_ROOT="your/local/path" python3 -m minerl.data.download "MineRLObtainDiamond-v0"
+    As an example, to download the full dataset for "MineRLObtainDiamond-v0", you can run
 
-    # Windows
-    $env:MINERL_DATA_ROOT="your/local/path"; python3 -m minerl.data.download "MineRLObtainDiamond-v0"
+    .. code-block:: bash
 
-For a complete list of published experiments, `checkout the environment documentation`_. You can also download the data
-in your python scripts 
+        python3 -m minerl.data.download --experiment "MineRLObtainDiamond-v0"
 
-Now we can build the datast for :code:`MineRLObtainDiamond-v0`
+
+
+For a complete list of published experiments, `check out the environment documentation`_.
+
+
+Sampling the Dataset with :code:`batch_iter`
+============================================
+
+Now we can build the dataset for :code:`MineRLObtainDiamond-v0`
 
 .. code-block:: python
 
-    data = minerl.data.make(
-        'MineRLObtainDiamond-v0')
-    
+    data = minerl.data.make('MineRLObtainDiamond-v0')
 
     for current_state, action, reward, next_state, done \
         in data.batch_iter(
@@ -66,20 +94,16 @@ Now we can build the datast for :code:`MineRLObtainDiamond-v0`
                   "can be < max_sequence_len", len(reward))
 
 
-.. warning:: 
-    The :code:`minerl` package uses environment variables to locate the data directory.
-    For portability, plese define :code:`MINERL_DATA_ROOT` as 
-    :code:`/your/local/path/` in your system environment variables.
 
 ..  admonition:: Solution
     :class: toggle
 
 
 Moderate Human Demonstrations
-_______________________________
+=============================
 
 MineRL-v0 uses community driven demonstrations to help researchers develop sample efficient techniques.
-Some of these demonstrations are less than optimal, however others could feacture bugs with the client,
+Some of these demonstrations are less than optimal, however others could feature bugs with the client,
 server errors, or adversarial behavior.
 
 Using the MineRL viewer, you can help curate this dataset by viewing these demonstrations manually and

--- a/minerl/data/download.py
+++ b/minerl/data/download.py
@@ -25,7 +25,7 @@ import coloredlogs
 logger = logging.getLogger(__name__)
 
 
-def download(directory=None, resolution='low', competition='minimal_all', texture_pack=0,
+def download(directory=None, resolution='low', competition=None, texture_pack=0,
              update_environment_variables=True, disable_cache=False,
              experiment=None):
     """Downloads MineRLv0 to specified directory. If directory is None, attempts to 
@@ -56,8 +56,12 @@ def download(directory=None, resolution='low', competition='minimal_all', textur
     if experiment is not None:
         logger.info("Downloading experiment {} to {}".format(experiment, directory))
     else:
+        if competition is None:
+            competition = 'minimal_all'
+
         logger.info("Downloading dataset for competition(s) {} to {}".format(competition,
                                                                              directory))
+
 
     if os.path.exists(directory):
         try:
@@ -92,6 +96,7 @@ def download(directory=None, resolution='low', competition='minimal_all', textur
         competition_string = competition + '_'
         if competition == 'minimal_all':
             min_str = '_minimal'
+            competition_string = ''
         else:
             min_str = ''
         filename = "v{}/{}data_texture_{}_{}_res{}.tar".format(DATA_VERSION,

--- a/minerl/data/download.py
+++ b/minerl/data/download.py
@@ -79,7 +79,7 @@ def download(directory=None, resolution='low', texture_pack=0,
         competition = 'minimal_all'
 
     if competition is not None:
-        logger.info("Downloading experiment set for {} competition(s)".format(competition))
+        logger.info("Downloading dataset for {} competition(s)".format(competition))
         competition_string = competition + '_'
         if competition == 'minimal_all':
             min_str = '_minimal'
@@ -161,7 +161,7 @@ if __name__ == '__main__':
         description=description,
     )
 
-    # Error if both --experiment and --competition provided
+    # Error if both --environment and --competition provided
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--environment",

--- a/minerl/data/download.py
+++ b/minerl/data/download.py
@@ -5,29 +5,26 @@ import os
 from urllib.error import URLError
 from urllib.error import HTTPError
 
-import requests
 import shutil
 import tarfile
-import minerl
 import time
-import tqdm
 from threading import Thread
 
 from minerl.data.util import download_with_resume
 
 import logging
 
-from minerl.data.version import VERSION_FILE_NAME, DATA_VERSION, assert_version
+from minerl.data.version import DATA_VERSION, assert_version
+from minerl.herobraine import envs
 import tempfile
-import sys
 import coloredlogs
 
 logger = logging.getLogger(__name__)
 
 
-def download(directory=None, resolution='low', competition=None, texture_pack=0,
+def download(directory=None, resolution='low', texture_pack=0,
              update_environment_variables=True, disable_cache=False,
-             experiment=None):
+             environment=None, competition=None):
     """Downloads MineRLv0 to specified directory. If directory is None, attempts to 
     download to $MINERL_DATA_ROOT. Raises ValueError if both are undefined.
     
@@ -35,7 +32,6 @@ def download(directory=None, resolution='low', competition=None, texture_pack=0,
         directory (os.path): destination root for downloading MineRLv0 datasets
         resolution (str, optional): one of [ 'low', 'high' ] corresponding to video resolutions of [ 64x64,1024x1024 ]
             respectively (note: high resolution is not currently supported). Defaults to 'low'.
-        competition(str): One of ['diamond', 'basalt', 'all'], default is minimal_all
         texture_pack (int, optional): 0: default Minecraft texture pack, 1: flat semi-realistic texture pack. Defaults
             to 0.
         update_environment_variables (bool, optional): enables / disables exporting of MINERL_DATA_ROOT environment
@@ -43,6 +39,7 @@ def download(directory=None, resolution='low', competition=None, texture_pack=0,
         disable_cache (bool, optional): downloads temporary files to local directory. Defaults to False
         experiment (str, optional): specify the desired experiment to download. Will only download data for this
             experiment. Note there is no hash verification for individual experiments
+        competition (str, optional): One of ['diamond', 'basalt'].
     """
     if directory is None:
         if 'MINERL_DATA_ROOT' in os.environ and len(os.environ['MINERL_DATA_ROOT']) > 0:
@@ -52,16 +49,6 @@ def download(directory=None, resolution='low', competition=None, texture_pack=0,
     elif update_environment_variables:
         os.environ['MINERL_DATA_ROOT'] = os.path.expanduser(
             os.path.expandvars(os.path.normpath(directory)))
-
-    if experiment is not None:
-        logger.info("Downloading experiment {} to {}".format(experiment, directory))
-    else:
-        if competition is None:
-            competition = 'minimal_all'
-
-        logger.info("Downloading dataset for competition(s) {} to {}".format(competition,
-                                                                             directory))
-
 
     if os.path.exists(directory):
         try:
@@ -88,10 +75,10 @@ def download(directory=None, resolution='low', competition=None, texture_pack=0,
         "https://minerl-asia.s3.amazonaws.com/",
         "https://minerl-europe.s3.amazonaws.com/"]
 
-    if experiment is None:
-        assert competition in ('diamond', 'basalt', 'minimal_all'), "competition has " \
-                                                            "unsupported value" \
-                                                            " {}".format(competition)
+    if environment is None and competition is None:
+        competition = 'minimal_all'
+
+    if competition is not None:
         logger.info("Downloading experiment set for {} competition(s)".format(competition))
         competition_string = competition + '_'
         if competition == 'minimal_all':
@@ -104,15 +91,12 @@ def download(directory=None, resolution='low', competition=None, texture_pack=0,
                                                                texture_pack,
                                                                resolution,
                                                                min_str)
-        urls = [mirror + filename for mirror in mirrors]
-
     else:
-        # Check if experiment is already downloaded
-        if os.path.exists(os.path.join(directory, experiment)):
-            logger.warning("{} exists - skipping re-download!".format(os.path.join(directory, experiment)))
-            return directory
-        filename = "v{}/{}.tar".format(DATA_VERSION, experiment)
-        urls = [mirror + filename for mirror in mirrors]
+        logger.info(f"Downloading dataset for {environment} to {directory}")
+        filename = f"v{DATA_VERSION}/{environment}.tar"
+
+    urls = [mirror + filename for mirror in mirrors]
+
     try:
         logger.info("Fetching download hash ...")
         # obj.fetch_hash_sums() 
@@ -124,8 +108,8 @@ def download(directory=None, resolution='low', competition=None, texture_pack=0,
         download_with_resume(urls, dest_file)
     except HTTPError as e:
         logger.error("HTTP {} error encountered when downloading files!".format(e.code))
-        if experiment is not None:
-            logger.error("Is \"{}\" a valid minerl environment?".format(experiment))
+        if environment is not None:
+            logger.error("Is \"{}\" a valid minerl environment?".format(environment))
         return None
     except URLError as e:
         logger.error("URL error encountered when downloading - please try again")
@@ -168,9 +152,43 @@ def download(directory=None, resolution='low', competition=None, texture_pack=0,
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--experiment", help="Specify a particular environment")
-    parser.add_argument("--competition", help="Explicitly download environments from either Diamond or BASALT")
+    description = """
+    Data download script for MineRL Diamond and BASALT competitions. Run this script with
+    no arguments to download a minimal dataset containing two demonstrations for every
+    environment.
+    """
+    parser = argparse.ArgumentParser(
+        description=description,
+    )
+
+    # Error if both --experiment and --competition provided
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--environment",
+        help="""
+        Download the full dataset for a particular environment, e.g
+        "MineRLBasaltBuildVillageHouse-v0".
+        """,
+        type=str,
+        action="store",
+        default=None,
+    )
+    group.add_argument(
+        "--competition",
+        help="Download the full dataset for a particular competition.",
+        type=str,
+        choices=["diamond", "basalt"],
+        default=None,
+    )
     args = parser.parse_args()
     coloredlogs.install(logging.DEBUG)
-    download(experiment=args.experiment, competition=args.competition)
+
+    # Sanity check that args.environment is valid before we proceed to download.
+    if args.environment is not None:
+        env_names = [env_spec.name for env_spec in envs.HAS_DATASET_ENV_SPECS]
+        if args.environment not in env_names:
+            logger.error(f"Invalid environment value, '{args.environment}'")
+            logger.error(f"Allowed values are: {env_names}")
+            exit(1)
+
+    download(environment=args.environment, competition=args.competition)


### PR DESCRIPTION
Adds Sphinx instructions on how to use `minerl.data.download`
in its default (minimal dataset mode) and its full dataset modes.

Rename --experiment to --environment because valid argument correspond to
Gym environment names.

Add sanity check that `--environment` value corresponds to one of our
environments that is expected to have a dataset, and prints out
valid environment names when this is wrong.

Merge two similar `if environment/competition is None` conditional branches
together.

```
- Get minimal_all download string (hopefully) correct
- WIP
- [DROP ME ON REBASE] docs: Move competition env spec list to `envs`
```
