### PR TITLE
publish.packgage: Stop generating mega tarball

### DIFF
--- a/minerl/data/pipeline/publish.py
+++ b/minerl/data/pipeline/publish.py
@@ -488,7 +488,6 @@ def package(out_dir=DATA_DIR):
     os.chdir(out_dir)
 
     # Generate tar archives
-    _make_tar(os.path.join(out_dir, 'data_texture_0_low_res.tar'), exp_folders)
     _make_tar(os.path.join(out_dir, 'basalt_data_texture_0_low_res.tar'), basalt_folders)
     _make_tar(os.path.join(out_dir, 'diamond_data_texture_0_low_res.tar'), diamond_folders)
 


### PR DESCRIPTION
As of #514, we no longer have an option to download the tarball that contains all the demonstrations at once (instead we can download large tarballs that download each competition's dataset). This PR removes the publish.py logic for generating the "everything" tarball.