### PR TITLE
malmo metadata: Mod "in-the-wild" metadata by 16

### DIFF
--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/ObservationFromEquippedItemImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/ObservationFromEquippedItemImplementation.java
@@ -43,7 +43,7 @@ public class ObservationFromEquippedItemImplementation extends HandlerBase imple
             {
                 String type = MineRLTypeHelper.getItemType(itemToAdd.getItem());
                 jobj.addProperty("type", type);
-                jobj.addProperty("metadata", itemToAdd.getMetadata());
+                jobj.addProperty("metadata", itemToAdd.getMetadata() % 16);
                 jobj.addProperty("quantity", itemToAdd.getCount());
                 if(itemToAdd.isItemStackDamageable()){
                     jobj.addProperty("currentDamage", itemToAdd.getItemDamage());

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/MineRLTypeHelper.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/MineRLTypeHelper.java
@@ -27,7 +27,9 @@ public class MineRLTypeHelper {
     }
 
     public static void writeItemStackToJson(ItemStack stack, JsonObject jsonObject) {
-        int metadata = stack.getMetadata();
+        // Mod by 16 to get the variant component of metadata. This could be a "in-the-wild" item stack with a metadata
+        // value above 15, unlike the items we spawn the player with.
+        int metadata = stack.getMetadata() % 16;
         validateMetadata(metadata);
         jsonObject.addProperty("type", MineRLTypeHelper.getItemType(stack.getItem()));
         jsonObject.addProperty("metadata", metadata);
@@ -69,7 +71,7 @@ public class MineRLTypeHelper {
             }
 
             boolean flagItemTypeMatches = regName.equals(targetRegName);
-            boolean flagItemMetadataMatches = (metadata == null) || (metadata == stack.getMetadata());
+            boolean flagItemMetadataMatches = (metadata == null) || (metadata == stack.getMetadata() % 16);
 
             if (flagItemTypeMatches && flagItemMetadataMatches) {
                 return i;

--- a/minerl/herobraine/hero/handlers/agent/actions/equip.py
+++ b/minerl/herobraine/hero/handlers/agent/actions/equip.py
@@ -43,6 +43,7 @@ class EquipAction(action.ItemWithMetadataListAction):
 
             item_type = mc.strip_item_prefix(hotbar_slot['name'])
             metadata = hotbar_slot['variant']
+            assert metadata in range(16)
             id = util.get_unique_matching_item_list_id(self.items, item_type, metadata,
                                                        clobber_logs=False)
             if id is None:

--- a/minerl/herobraine/hero/handlers/agent/observations/equipped_item.py
+++ b/minerl/herobraine/hero/handlers/agent/observations/equipped_item.py
@@ -141,6 +141,7 @@ class _ItemIDObservation(TranslationHandler):
                 head = head[key]
             item_type = head['type']
             metadata = head['metadata']
+            assert metadata in range(16)
             item_id = util.get_unique_matching_item_list_id(self._items, item_type, metadata)
             if item_id is None:
                 return self._other
@@ -163,6 +164,7 @@ class _ItemIDObservation(TranslationHandler):
 
                 item_type = mc.strip_item_prefix(equip_slot['name'])
                 metadata = equip_slot['variant']
+                assert metadata in range(16)
                 if item_type == 'air':
                     return self._default
 


### PR DESCRIPTION
Sometimes the metadata value we see in Malmo is greater than 15, leading to RuntimeExceptions. The reason that this is happening is because "in-the-wild" item stacks, like arbitrary blocks that the player picks up, could have non-variant metadata inside it.

This PR hopefully prevents these exceptions by modding "in-the-wild" ItemStack.getMetadata() by 16. 

- malmo metadata: Mod "in-the-wild" metadata by 16.
- equip handlers: Add new metadata assertions
