### PR TITLE
Fix copy-paste error for Caves inventory

### DIFF
--- a/minerl/herobraine/env_specs/basalt_specs.py
+++ b/minerl/herobraine/env_specs/basalt_specs.py
@@ -271,10 +271,6 @@ snowball to end episode.
             max_episode_steps=3*MINUTE,
             high_res=high_res,
             inventory=[
-                dict(type="water_bucket", quantity=1),
-                dict(type="cobblestone", quantity=20),
-                dict(type="stone_shovel", quantity=1),
-                dict(type="stone_pickaxe", quantity=1),
                 dict(type="snowball", quantity=1),
             ],
         )


### PR DESCRIPTION
The documentation for Caves incorrectly states that the starting inventory is that of Waterfall.