### PR TITLE
basalt envs: Fix and test snowball throw wrapper

### DIFF
--- a/tests/env_smoke_test.py
+++ b/tests/env_smoke_test.py
@@ -5,6 +5,7 @@ import minerl
 from minerl.herobraine import envs
 
 ENV_NAMES = [env_spec.name for env_spec in envs.ENV_SPECS]
+BASALT_ENV_NAMES = [env_spec.name for env_spec in envs.BASALT_COMPETITION_ENV_SPECS]
 
 
 @pytest.mark.parametrize("env_name", ENV_NAMES)
@@ -24,3 +25,23 @@ def test_envs_step_smoke(env_name):
             assert isinstance(done, bool)
             assert isinstance(info, dict)
             assert obs in env.observation_space
+
+
+@pytest.mark.parametrize("env_name", BASALT_ENV_NAMES)
+def test_basalt_end_soon_after_snowball(env_name):
+    """Basalt environment should terminate within 20 steps
+    (really should only take
+    13 steps = 10 steps snowball-episode-end-countdown + 3 steps Malmo equip delay,
+    but adding some leeway here.
+    )"""
+    with gym.make(env_name) as env:
+        obs = env.reset()
+        throw_act = env.action_space.noop()
+        throw_act["equip"] = "snowball"
+        throw_act["use"] = 1
+        for _ in range(20):
+            obs, rew, done, info = env.step(throw_act)
+            print(obs["inventory"]["snowball"])
+            if done:
+                break
+        assert done

--- a/tests/env_smoke_test.py
+++ b/tests/env_smoke_test.py
@@ -27,6 +27,7 @@ def test_envs_step_smoke(env_name):
             assert obs in env.observation_space
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize("env_name", BASALT_ENV_NAMES)
 def test_basalt_end_soon_after_snowball(env_name):
     """Basalt environment should terminate within 20 steps


### PR DESCRIPTION
Old code failed to throw snowball because of off-by-one error -- the equipped_item type observation would no longer be "snowball" on the same tick that `actions["use"] == 1`, because the observation we receive in `observation, reward, done, info = super().step(action)` comes from the step after the snowball is thrown. Therefore, we used to never terminate the episode on an actual snowball throw because `observation` here would report that no item was equipped (the snowball was already thrown by the time we see `observation`).
