### PR TITLE
publish: Fix empty-inventory on air-stack bug

### DIFF
--- a/minerl/herobraine/hero/handlers/agent/observations/equipped_item.py
+++ b/minerl/herobraine/hero/handlers/agent/observations/equipped_item.py
@@ -6,6 +6,7 @@
 Not very proud of the code reuse in this module -- @wguss
 """
 
+import os
 from typing import List, Sequence
 
 from minerl.herobraine.hero import mc
@@ -171,7 +172,8 @@ class _ItemIDObservation(TranslationHandler):
                 item_id = util.get_unique_matching_item_list_id(
                     self._items, item_type, metadata)
                 if item_id is None:
-                    print(f"Unknown item: '{item_type}#{metadata}'")
+                    if os.environ.get("MINERL_DEBUG_LOG", False):
+                        print(f"Unknown item: '{item_type}#{metadata}'")
                     return self._other
                 else:
                     return item_id

--- a/minerl/herobraine/hero/handlers/agent/observations/inventory.py
+++ b/minerl/herobraine/hero/handlers/agent/observations/inventory.py
@@ -114,8 +114,13 @@ class FlatInventoryObservation(TranslationHandler):
             for stack in slots:
                 item_type = mc.strip_item_prefix(stack['name']) if len(stack.keys()) != 0 else "air"
 
-                if item_type == "air" and item_type in self.items:
-                    item_dict[item_type] += 1  # This lets us count empty slots -non default MC behavior
+                if item_type == "air":
+                    # We don't expect to actually see any slots with `stack['name'] == 'air'`,
+                    # (air should be an empty dictionary stack) but if we do,
+                    # `stack['name'] == 'air'` is also covered under this case.
+                    if item_type in self.items:
+                        # This lets us count empty slots non-default MC behavior
+                        item_dict[item_type] += 1
                 else:
                     unique = util.get_unique_matching_item_list_id(
                         self.items, item_type, stack['variant'])


### PR DESCRIPTION
Fix an error where empty stacks errored on "KeyError: variant" when "air" was not an item inside `item_list`.

Also, reduces verbosity of `publish.py` stage of rerendering pipeline by only outputting "unknown item" messages when `MINERL_DEBUG_LOG` env var is set.