### PR TITLE
Hotfix: Robustify Village spawn procedure

### DIFF
--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/VillageSpawnDecoratorImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/VillageSpawnDecoratorImplementation.java
@@ -76,7 +76,7 @@ public class VillageSpawnDecoratorImplementation extends HandlerBase implements 
             System.out.println("Selected start:" + blockPos.toString());
             PosAndDirection xmlPos = new PosAndDirection();
             xmlPos.setX(BigDecimal.valueOf(blockPos.getX() + 0.5));
-            xmlPos.setY(BigDecimal.valueOf(blockPos.getY()));
+            xmlPos.setY(BigDecimal.valueOf(blockPos.getY() + 2));
             xmlPos.setZ(BigDecimal.valueOf(blockPos.getZ() + 0.5));
 
             System.out.println(String.format("====2 xmlPos (%f, %f, %f)%n",

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/VillageSpawnDecoratorImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/VillageSpawnDecoratorImplementation.java
@@ -28,7 +28,6 @@ import com.microsoft.Malmo.Utils.PositionHelper;
 import com.microsoft.Malmo.Utils.SeedHelper;
 
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
 import java.math.BigDecimal;
@@ -48,7 +47,6 @@ public class VillageSpawnDecoratorImplementation extends HandlerBase implements 
     // Random number generators for path generation / block choosing:
     private Random rand = SeedHelper.getRandom("agentStart");;
 
-    private PosAndDirection startPosition = null;
     private VillageSpawnDecorator params = null;
 
 
@@ -67,20 +65,23 @@ public class VillageSpawnDecoratorImplementation extends HandlerBase implements 
         for (AgentSection as : missionInit.getMission().getAgentSection())
         {
             BlockPos blockPos = world.findNearestStructure("Village", world.getSpawnPoint(), false);
+            System.out.println("====0 blockPos (before getTopTeleportable)" + blockPos.toString());
 
-            BlockPos new_pos = PositionHelper.getTopSolidOrLiquidBlock(world, blockPos);
-            new_pos = new_pos.add(0.5, 0, 0.5);
+            // `PositionHelper.getTopTeleportableBlock(world, blockPos);` has a more reassuring sounding name, but
+            // these two "getTop" helper functions seem to work about the same in terms of chance of spawning the
+            // player inside a wall, which leads to "suffocation" death within the first 5 frames.
+            blockPos = PositionHelper.getTopSolidOrLiquidBlock(world, blockPos);
+            System.out.println("====1 blockPos (after getTop..Block)" + blockPos.toString());
 
-            System.out.println("Selected start:" + new_pos.toString());
+            System.out.println("Selected start:" + blockPos.toString());
             PosAndDirection xmlPos = new PosAndDirection();
-            xmlPos.setX(new BigDecimal(new_pos.getX()));
-            xmlPos.setY(new BigDecimal(new_pos.getY()));
-            xmlPos.setZ(new BigDecimal(new_pos.getZ()));
-            System.out.println("Set start!");
+            xmlPos.setX(BigDecimal.valueOf(blockPos.getX() + 0.5));
+            xmlPos.setY(BigDecimal.valueOf(blockPos.getY()));
+            xmlPos.setZ(BigDecimal.valueOf(blockPos.getZ() + 0.5));
 
-            // I have no clue which of these statements is actually working...
-            world.setSpawnPoint(new_pos);
-            this.startPosition = xmlPos;
+            System.out.println(String.format("====2 xmlPos (%f, %f, %f)%n",
+                    xmlPos.getX().floatValue(), xmlPos.getY().floatValue(), xmlPos.getZ().floatValue()));
+
             as.getAgentStart().setPlacement(xmlPos);
         }
     }
@@ -95,17 +96,7 @@ public class VillageSpawnDecoratorImplementation extends HandlerBase implements 
     public void update(World world) {}
 
     @Override
-    public boolean getExtraAgentHandlersAndData(List<Object> handlers, Map<String, String> data)
-    {
-        // Also add our new start data:
-        Float x = this.startPosition.getX().floatValue();
-        Float y = this.startPosition.getY().floatValue();
-        Float z = this.startPosition.getZ().floatValue();
-        String posString = x.toString() + ":" + y.toString() + ":" + z.toString();
-        data.put("startPosition", posString);
-
-        return false;
-    }
+    public boolean getExtraAgentHandlersAndData(List<Object> handlers, Map<String, String> data) { return false; }
 
     @Override
     public void prepare(MissionInit missionInit)

--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/VillageSpawnDecoratorImplementation.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/VillageSpawnDecoratorImplementation.java
@@ -63,23 +63,25 @@ public class VillageSpawnDecoratorImplementation extends HandlerBase implements 
 
     private void teleportAgents(MissionInit missionInit, World world)
     {
-        PosAndDirection pos = new PosAndDirection();
         // Force all players to being at a random starting position
         for (AgentSection as : missionInit.getMission().getAgentSection())
         {
             BlockPos blockPos = world.findNearestStructure("Village", world.getSpawnPoint(), false);
 
             BlockPos new_pos = PositionHelper.getTopSolidOrLiquidBlock(world, blockPos);
+            new_pos = new_pos.add(0.5, 0, 0.5);
+
             System.out.println("Selected start:" + new_pos.toString());
-            pos.setX(new BigDecimal(new_pos.getX() + 0.5));
-            pos.setY(new BigDecimal(new_pos.getY()));
-            pos.setZ(new BigDecimal(new_pos.getZ() + 0.5));
+            PosAndDirection xmlPos = new PosAndDirection();
+            xmlPos.setX(new BigDecimal(new_pos.getX()));
+            xmlPos.setY(new BigDecimal(new_pos.getY()));
+            xmlPos.setZ(new BigDecimal(new_pos.getZ()));
             System.out.println("Set start!");
 
             // I have no clue which of these statements is actually working...
             world.setSpawnPoint(new_pos);
-            this.startPosition = pos;
-            as.getAgentStart().setPlacement(pos);
+            this.startPosition = xmlPos;
+            as.getAgentStart().setPlacement(xmlPos);
         }
     }
 

--- a/minerl/herobraine/env_specs/basalt_specs.py
+++ b/minerl/herobraine/env_specs/basalt_specs.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Sequence
 import gym
 
 from minerl.env import _fake, _singleagent
+from minerl.herobraine import wrappers
 from minerl.herobraine.env_spec import EnvSpec
 from minerl.herobraine.env_specs import simple_embodiment
 from minerl.herobraine.hero import handlers, mc
@@ -122,6 +123,13 @@ def _basalt_gym_entrypoint(
         env = _fake._FakeSingleAgentEnv(env_spec=env_spec)
     else:
         env = _singleagent._SingleAgentEnv(env_spec=env_spec)
+
+    if "Village" in env_spec.name:
+        # Quick hack to mitigate die-due-to-suffocate-in-wall-on-spawn problem.
+        # The proper solution is to make sure the VillageSpawnDecoratorImplementation.java
+        # chooses a spawn location that isn't instead a wall.
+        env = wrappers.RetryResetOnEarlyDeathWrapper(env)
+
     if end_after_snowball_throw:
         env = EndAfterSnowballThrowWrapper(env)
     return env

--- a/minerl/herobraine/wrappers/__init__.py
+++ b/minerl/herobraine/wrappers/__init__.py
@@ -3,3 +3,6 @@
 
 from minerl.herobraine.wrappers.obfuscation_wrapper import Obfuscated
 from minerl.herobraine.wrappers.vector_wrapper import Vectorized
+from minerl.herobraine.wrappers.downscale_wrapper import DownscaleWrapper
+from minerl.herobraine.wrappers.retry_reset_on_early_death_wrapper import (
+    RetryResetOnEarlyDeathWrapper)

--- a/minerl/herobraine/wrappers/retry_reset_on_early_death_wrapper.py
+++ b/minerl/herobraine/wrappers/retry_reset_on_early_death_wrapper.py
@@ -1,0 +1,69 @@
+import logging
+
+import gym
+
+
+def _agent_seems_alive(obs: dict) -> bool:
+    """Return True if there are any items in inventory (a telltale sign of agent death is
+    dropping all items)"""
+    inventory = obs["inventory"]
+    for count in inventory.values():
+        if count > 0:
+            return True
+    return False
+
+
+class RetryResetOnEarlyDeathWrapper(gym.Wrapper):
+    """
+    Apply this wrapper directly over a MineRLEnv with a VillageSpawnDecorator to
+    reset() when the agent dies ~instantly due to spawning inside a wall.
+
+    Can also make it seem as if the agent spawned on the ground instead of in the air
+    because as a side effect this wrapper will call `self.env.step(noop_act)` several
+    times to check if the player has died immediately after `reset()`.
+
+    WARNING: This wrapper may have unexpected interactions with `seed()`, which otherwise
+    guarantees that the agent spawns in the ~same village every time.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, env, n_reset_attempts=3, n_noops=30):
+        assert n_reset_attempts > 0
+        assert n_noops >= 0
+        self.n_reset_attempts = n_reset_attempts
+        self.n_noops = n_noops
+        super().__init__(env)
+
+    def reset(self):
+        for attempt_count in range(self.n_reset_attempts):
+            obs = self.env.reset()
+            # noop() is not guaranteed to exist unless `self.env` is a MineRLEnv.
+            # Therefore, this wrapper should be directly applied on top of the MineRLEnv.
+            noop_act = self.env.action_space.noop()
+
+            done = False
+            for _ in range(self.n_noops):
+                obs, _, done, _ = self.env.step(noop_act)
+                if done:
+                    # Environment ended early for some reason. Assume early death and
+                    # continue on to the next reset attempt.
+                    break
+
+            if not done and _agent_seems_alive(obs):
+                # Agent has survived for n_noop steps. We are now ready to start the
+                # episode in earnest.
+                return obs
+            else:
+                self.logger.info(
+                    f"Agent died within {self.n_noops} ticks after reset "
+                    f"(attempt {attempt_count + 1} out of {self.n_reset_attempts}). "
+                    "For more information on death circumstances, set environment variable "
+                    "MINERL_DEBUG_LOG=1 to see more Malmo/Minecraft logs."
+                )
+
+        # We failed to return
+        raise RuntimeError(
+            f"Agent died within {self.n_noops} steps every time in each of "
+            f"{self.n_reset_attempts} attempts"
+        )

--- a/minerl/herobraine/wrappers/retry_reset_on_early_death_wrapper.py
+++ b/minerl/herobraine/wrappers/retry_reset_on_early_death_wrapper.py
@@ -62,7 +62,6 @@ class RetryResetOnEarlyDeathWrapper(gym.Wrapper):
                     "MINERL_DEBUG_LOG=1 to see more Malmo/Minecraft logs."
                 )
 
-        # We failed to return
         raise RuntimeError(
             f"Agent died within {self.n_noops} steps every time in each of "
             f"{self.n_reset_attempts} attempts"


### PR DESCRIPTION
Previously we had an issue where players would die suddenly after `reset()` (within the first 3 frames) because they spawned inside a wall.

This would lead to videos where we see all of the players items flying in every direction, including the snowball, which would trigger an episode end due to the EndEpisodeOnSnowballThrowWrapper. (It's not clear why the snowball ends the episode, and not the actual player death).

This hotfix combines two hacks to reduce the chance of player death.
(1) Spawn the player 2 blocks above the suggested village spawn location. Empirically, this seems to reduce the probability of dying immediately on reset. We can reduce the probability of dying even further by spawning the player 6 blocks above the suggested village spawn location.

(2) Add a wrapper that upon `env.reset()`, checks that the player hasn't dropped all their items for 30 noop actions. If the player hasn't died in that time frame, then the spawn is likely OK. If the player died in that time frame, then retry reset up to 3 times.