### PR TITLE
Add note on interactor being broken in v0.4

### DIFF
--- a/docs/source/tutorials/minerl_tools.rst
+++ b/docs/source/tutorials/minerl_tools.rst
@@ -73,6 +73,12 @@ Interactive Mode :code:`minerl.interactor`
 =============================================================
 
 
+.. warning::
+
+    The interactor does not function in MineRL version v0.4. If you wish to use this utility,
+    install an older version of MineRL ``pip install minerl=0.3.7``.
+
+
 Once you have started training agents, the next step is getting them to interact with human players.
 To help achieve this, the :code:`minerl` python package provides a interactive Minecraft client called
 :code:`minerl.interactor`:


### PR DESCRIPTION
For the soon-to-be-done v0.4 update, the interactor is still broken and fixing it would probably delay the package by quite some time. This PR adds a note on this, instructing people to install 0.3.7 if they want to use interactor.

@brandonhoughton Did you happen to have some working interactor code somewhere? If so, ping me and I can help getting it working with this codebase.
