### PR TITLE
Make viewer main more modular

### DIFF
--- a/minerl/viewer/__main__.py
+++ b/minerl/viewer/__main__.py
@@ -5,12 +5,9 @@
 Calls the data viewer.
 """
 
-import argparse
 import logging
 import random
 import coloredlogs
-import time
-import numpy as np
 
 import minerl
 from minerl.viewer import get_parser
@@ -20,33 +17,34 @@ coloredlogs.install(logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-def main(opts):
+def main(env_name: str, stream_name: str):
     logger.info("Welcome to the MineRL Stream viewer! \n")
 
-    logger.info("Building data pipeline for {}".format(opts.environment))
-    data = minerl.data.make(opts.environment)
+    logger.info(f"Building data pipeline for {env_name}")
+    data = minerl.data.make(env_name)
 
     # for _ in data.seq_iter( 1, -1, None, None, include_metadata=True):
     #     print(_[-1])
     #     pass
-    if opts.stream_name is None:
+    if stream_name is None:
         trajs = data.get_trajectory_names()
-        opts.stream_name = random.choice(trajs)
+        stream_name = random.choice(trajs)
 
-    logger.info("Loading data for {}...".format(opts.stream_name))
-    data_frames = list(data.load_data(opts.stream_name, include_metadata=True))
+    logger.info(f"Loading data for {stream_name}...")
+    data_frames = list(data.load_data(stream_name, include_metadata=True))
     meta = data_frames[0][-1]
-    logger.info("Data loading complete!".format(opts.stream_name))
-    logger.info("META DATA: {}".format(meta))
+    logger.info("Data loading complete!")
+    logger.info(f"META DATA: {meta}")
 
     trajectory_display_controller = TrajectoryDisplayController(
         data_frames,
-        header=opts.environment,
-        subtext=opts.stream_name,
-        vector_display='VectorObf' in opts.environment
+        header=env_name,
+        subtext=stream_name,
+        vector_display='VectorObf' in env_name
     )
     trajectory_display_controller.run()
 
 
 if __name__ == '__main__':
-    main(get_parser().parse_args())
+    args = get_parser().parse_args()
+    main(env_name=args.environment, stream_name=args.stream_name)


### PR DESCRIPTION
(This way my wrapper scripts can call `main` directly, without
using `argparse`).
