### PR TITLE
translation: Remove unpicklable self.logger

### DIFF
--- a/minerl/herobraine/hero/handlers/translation.py
+++ b/minerl/herobraine/hero/handlers/translation.py
@@ -63,7 +63,10 @@ class KeymapTranslationHandler(TranslationHandler):
         self.univ_keys = univ_keys
         self.default_if_missing = default_if_missing
         # TODO (R): UNIFY THE LOGGING FRAMEWORK FOR MINERL
-        self.logger = logging.getLogger(f'{__name__}.{self.to_string()}')
+
+    @property
+    def logger(self):
+        return logging.getLogger(f'{__name__}.{self.to_string()}')
 
     def walk_dict(self, d, keys):
         for key in keys:

--- a/minerl/herobraine/hero/handlers/translation.py
+++ b/minerl/herobraine/hero/handlers/translation.py
@@ -62,7 +62,6 @@ class KeymapTranslationHandler(TranslationHandler):
         self.hero_keys = hero_keys
         self.univ_keys = univ_keys
         self.default_if_missing = default_if_missing
-        # TODO (R): UNIFY THE LOGGING FRAMEWORK FOR MINERL
 
     @property
     def logger(self):


### PR DESCRIPTION
This was causing a py3.6 incompatibility because Logger is unpicklable until py3.7.