### PR TITLE
download: Update docs and assertions

### DIFF
--- a/docs/source/tutorials/data_sampling.rst
+++ b/docs/source/tutorials/data_sampling.rst
@@ -88,8 +88,7 @@ The recommended way of sampling from the dataset is:
 .. code-block:: python
 
     from minerl.data import BufferedBatchIter
-    data = minerl.data.make(
-        'MineRLObtainDiamond-v0')
+    data = minerl.data.make('MineRLObtainDiamond-v0')
     iterator = BufferedBatchIter(data)
     for current_state, action, reward, next_state, done \
         in iterator.buffered_batch_iter(batch_size=1, num_epochs=1):

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -5,8 +5,7 @@ Installation
 Welcome to MineRL! This guide will get you started.
 
 
-To start using the data and set of reinforcement learning
-environments comprising MineRL, you'll need to install the
+To start using the MineRL dataset and Gym environments comprising MineRL, you'll need to install the
 main python package, :code:`minerl`.
 
 .. _OpenJDK 8: https://openjdk.java.net/install/
@@ -36,33 +35,5 @@ main python package, :code:`minerl`.
         pip3 install --upgrade minerl
 
 .. note::
-        depending on your system you may need the user flag:
-        :code:`pip3 install --upgrade minerl --user` to install property
-
-3. (Optional) Download the dataset ~ 60 GB:
-
-   .. code-block:: python
-
-        import minerl
-        minerl.data.download(directory="/your/local/path/")
-
-   Or simply download a single experiment
-
-   .. code-block:: python
-
-        minerl.data.download('/your/local/path',experiment='MineRLObtainDiamondVectorObf-v0')
-
-   For a complete list of published experiments, `checkout the environment documentation`_.
-   If you are here for the MineRL competition, `checkout the competition environments`_.
-
-**That's it! Now you're good to go :) 💯💯💯**
-
-.. caution::
-    Currently :code:`minerl` only supports environment rendering in **headed environments**
-    (machines with monitors attached). 
-
-
-    **In order to run** :code:`minerl` **environments without a head use a software renderer
-    such as** :code:`xvfb`::
-
-        xvfb-run python3 <your_script.py>
+        You may need the user flag:
+        :code:`pip3 install --upgrade minerl --user` to install properly.

--- a/minerl/data/download.py
+++ b/minerl/data/download.py
@@ -17,30 +17,73 @@ import logging
 from minerl.data.version import DATA_VERSION, assert_version
 from minerl.herobraine import envs
 import tempfile
+from typing import Optional
 import coloredlogs
 
 logger = logging.getLogger(__name__)
 
 
-def download(directory=None, resolution='low', texture_pack=0,
-             update_environment_variables=True, disable_cache=False,
-             environment=None, competition=None):
-    """Downloads MineRLv0 to specified directory. If directory is None, attempts to 
-    download to $MINERL_DATA_ROOT. Raises ValueError if both are undefined.
-    
+def download(
+        environment: Optional[str] = None,
+        competition: Optional[str] = None,
+        directory: Optional[str] = None,
+        resolution: str = 'low',
+        texture_pack: int = 0,
+        update_environment_variables: bool = True,
+        disable_cache: bool = False,
+) -> None:
+    """Low-level interface for downloading MineRL dataset.
+
+    Using the `python -m minerl.data.download` CLI script is preferred because it performs
+    more input validation and hides internal-use arguments.
+
+    Run this command with `environment=None` and `competition=None` to download a minimal
+    dataset with 2 demonstrations from each environment.
+    Provide the `environment` or `competition` arguments to download a full dataset for
+    a particular environment or competition.
+
     Args:
-        directory (os.path): destination root for downloading MineRLv0 datasets
-        resolution (str, optional): one of [ 'low', 'high' ] corresponding to video resolutions of [ 64x64,1024x1024 ]
-            respectively (note: high resolution is not currently supported). Defaults to 'low'.
-        texture_pack (int, optional): 0: default Minecraft texture pack, 1: flat semi-realistic texture pack. Defaults
-            to 0.
-        update_environment_variables (bool, optional): enables / disables exporting of MINERL_DATA_ROOT environment
-            variable (note: for some os this is only for the current shell) Defaults to True.
-        disable_cache (bool, optional): downloads temporary files to local directory. Defaults to False
-        experiment (str, optional): specify the desired experiment to download. Will only download data for this
-            experiment. Note there is no hash verification for individual experiments
-        competition (str, optional): One of ['diamond', 'basalt'].
+        environment: The name of a MineRL environment or None. If this argument is the
+            name of a MineRL environment and `competition` is None, then this function
+            downloads the full dataset for the specifies MineRL environment.
+
+            If both `environment=None` and `competition=None`, then this function
+            downloads a minimal dataset.
+        competition: The name of a MineRL competition ("diamond" or "basalt") or None. If
+            this argument is the name of a MineRL environment and `competition` is None,
+            then this function downloads the full dataset for the specified MineRL
+            competition.
+
+            If both `environment=None` and `competition=None`, then this function
+            downloads a minimal dataset.
+        directory: Destination folder for downloading MineRL datasets. If None, then use
+            the `MINERL_DATA_ROOT` environment variable, or error if this environment
+            variable is not set.
+        resolution: For internal use only. One of ['low', 'high'] corresponding to video
+            resolutions of [64x64,1024x1024] respectively (note: high resolution is not currently
+            supported).
+        texture_pack: For internal use only. 0: default Minecraft texture
+            pack, 1: flat semi-realistic texture pack.
+        update_environment_variables: For internal use only. If True, then export of
+            MINERL_DATA_ROOT environment variable (note: for some os this is only for the
+            current shell).
+        disable_cache: If False (default), then the tar download and other temporary
+            download files are saved inside `directory`.
+
+            If disable_cache is False on
+            a future call to this function and temporary download files are detected, then
+            the download is resumed from previous download progress. If disable_cache is
+            False on a future call to this function and the completed tar file is
+            detected, then the download is skipped entirely and we immediately extract the tar
+            to `directory`.
     """
+    assert texture_pack in (0, 1)
+    if competition is not None and environment is not None:
+        raise ValueError(
+            f"At most one of the `competition={competition}` and `environment={environment}` "
+            "arguments can be non-None."
+        )
+
     if directory is None:
         if 'MINERL_DATA_ROOT' in os.environ and len(os.environ['MINERL_DATA_ROOT']) > 0:
             directory = os.environ['MINERL_DATA_ROOT']
@@ -151,11 +194,14 @@ def download(directory=None, resolution='low', texture_pack=0,
     return directory
 
 
-if __name__ == '__main__':
+def main():
     description = """
     Data download script for MineRL Diamond and BASALT competitions. Run this script with
     no arguments to download a minimal dataset containing two demonstrations for every
     environment.
+
+    See https://minerl.io/docs/tutorials/data_sampling.html#setting-up-environment-variables
+    for example usage of this script.
     """
     parser = argparse.ArgumentParser(
         description=description,
@@ -192,3 +238,6 @@ if __name__ == '__main__':
             exit(1)
 
     download(environment=args.environment, competition=args.competition)
+
+if __name__ == '__main__':
+    main()

--- a/minerl/data/download.py
+++ b/minerl/data/download.py
@@ -200,7 +200,7 @@ def main():
     no arguments to download a minimal dataset containing two demonstrations for every
     environment.
 
-    See https://minerl.io/docs/tutorials/data_sampling.html#setting-up-environment-variables
+    See https://minerl.readthedocs.io/en/latest/tutorials/data_sampling.html
     for example usage of this script.
     """
     parser = argparse.ArgumentParser(

--- a/minerl/data/download.py
+++ b/minerl/data/download.py
@@ -24,9 +24,9 @@ logger = logging.getLogger(__name__)
 
 
 def download(
+        directory: Optional[str] = None,
         environment: Optional[str] = None,
         competition: Optional[str] = None,
-        directory: Optional[str] = None,
         resolution: str = 'low',
         texture_pack: int = 0,
         update_environment_variables: bool = True,
@@ -43,6 +43,9 @@ def download(
     a particular environment or competition.
 
     Args:
+        directory: Destination folder for downloading MineRL datasets. If None, then use
+            the `MINERL_DATA_ROOT` environment variable, or error if this environment
+            variable is not set.
         environment: The name of a MineRL environment or None. If this argument is the
             name of a MineRL environment and `competition` is None, then this function
             downloads the full dataset for the specifies MineRL environment.
@@ -56,9 +59,6 @@ def download(
 
             If both `environment=None` and `competition=None`, then this function
             downloads a minimal dataset.
-        directory: Destination folder for downloading MineRL datasets. If None, then use
-            the `MINERL_DATA_ROOT` environment variable, or error if this environment
-            variable is not set.
         resolution: For internal use only. One of ['low', 'high'] corresponding to video
             resolutions of [64x64,1024x1024] respectively (note: high resolution is not currently
             supported).

--- a/minerl/data/download.py
+++ b/minerl/data/download.py
@@ -239,5 +239,6 @@ def main():
 
     download(environment=args.environment, competition=args.competition)
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Updates `download` function documentation, in particular noting the `experiment` => `environment` change (sorry for this stealth change earlier), and noting which arguments are "internal" on which ones are external.

I also moved the important (public-facing) arguments in `download()` earlier in the argument list, and added some assertions

Broader question:
Does it seem like the right idea to document the `download` function as a low-level function, and point people towards using the `python -m minerl.data.download` script instead?