### PR TITLE
Add tasks to docs

### DIFF
--- a/docs/source/api/env.rst
+++ b/docs/source/api/env.rst
@@ -12,8 +12,8 @@ simulator Malmo which enables **synchronous**, **stable**, and
 MineRLEnv
 ===========
 
-.. automodule:: minerl.env.core
-    :members: MineRLEnv
+.. automodule:: minerl.env._multiagent
+    :members: _MultiAgentEnv
     :undoc-members:
     :show-inheritance:
 

--- a/docs/source/api/env.rst
+++ b/docs/source/api/env.rst
@@ -12,8 +12,8 @@ simulator Malmo which enables **synchronous**, **stable**, and
 MineRLEnv
 ===========
 
-.. automodule:: minerl.env._multiagent
-    :members: _MultiAgentEnv
+.. automodule:: minerl.env._singleagent
+    :members: _SingleAgentEnv
     :undoc-members:
     :show-inheritance:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,6 +84,7 @@ components:
    tutorials/index
    tutorials/first_agent
    tutorials/data_sampling
+   tutorials/more_examples
    tutorials/k-means
    tutorials/minerl_tools
 


### PR DESCRIPTION
Add the workshop tasks to docs along with link to baselines (they serve as nice examples). 