### PR TITLE
Fixed the download command with --environment flag

### DIFF
--- a/docs/source/tutorials/k-means.rst
+++ b/docs/source/tutorials/k-means.rst
@@ -29,7 +29,7 @@ To get started, let's download the `MineRLTreechopVectorObf-v0`_ environment.
 
 .. code-block:: bash
 
-    python -m minerl.data.download 'MineRLTreechopVectorObf-v0'
+    python -m minerl.data.download --environment 'MineRLTreechopVectorObf-v0'
 
 .. note::
 


### PR DESCRIPTION
Added the --environment flag to a download command on the [K-Means exploration](https://minerl.io/docs/tutorials/k-means.html) page.

Without it, it returns an error:
```
download.py: error: unrecognized arguments: MineRLTreechopVectorObf-v0
```