### PR TITLE
Hotfix for log4j security vunerability

### DIFF
--- a/minerl/Malmo/Minecraft/build.gradle
+++ b/minerl/Malmo/Minecraft/build.gradle
@@ -24,6 +24,16 @@ buildscript {
 
         classpath 'com.github.brandonhoughton:ForgeGradle:FG_2.2_patched-SNAPSHOT'
     }
+    configurations {
+        compileClasspath {
+            resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+                if (details.requested.group == 'org.apache.logging.log4j') {
+                    details.useVersion '2.15.0'
+                    details.because 'zero-day-exploits on log4j <2.15.0'
+                }
+            }
+        }
+    }
 }
 
 plugins {


### PR DESCRIPTION
Update log4j to 2.15.0 to mitigate risks of cve-2021-44228