### PR TITLE
Fix interactor

### DIFF
--- a/docs/source/tutorials/minerl_tools.rst
+++ b/docs/source/tutorials/minerl_tools.rst
@@ -75,8 +75,9 @@ Interactive Mode :code:`minerl.interactor`
 
 .. warning::
 
-    The interactor does not function in MineRL version v0.4. If you wish to use this utility,
-    install an older version of MineRL ``pip install minerl=0.3.7``.
+    Interactor works in MineRL versions 0.3.7 and 0.4.4 (or above). 
+    Install 0.3.7 with ``pip install minerl==0.3.7``, or the newest MineRL
+    with ``pip install git+https://github.com/minerllabs/minerl.git@dev``.
 
 
 Once you have started training agents, the next step is getting them to interact with human players.

--- a/minerl/env/_multiagent.py
+++ b/minerl/env/_multiagent.py
@@ -478,6 +478,7 @@ class _MultiAgentEnv(gym.Env):
             # the port/ip of the master agent send the remaining XMLS.
 
             self._send_mission(self.instances[0], agent_xmls[0], self._get_token(0, ep_uid))  # Master
+            time.sleep(10)
             if self.task.agent_count > 1:
                 mc_server_ip, mc_server_port = self._TO_MOVE_find_ip_and_port(self.instances[0],
                                                                               self._get_token(1, ep_uid))

--- a/minerl/herobraine/hero/spaces.py
+++ b/minerl/herobraine/hero/spaces.py
@@ -203,7 +203,7 @@ class Discrete(gym.spaces.Discrete, MineRLSpace):
     def __init__(self, *args, **kwargs):
         super(Discrete, self).__init__(*args, **kwargs)
         self.eye = np.eye(self.n, dtype=np.float32)
-        self.shape = ()
+        #self.shape = () #can't set attribute
 
     def no_op(self, batch_shape=()):
         if len(batch_shape) == 0:

--- a/minerl/herobraine/hero/spaces.py
+++ b/minerl/herobraine/hero/spaces.py
@@ -203,7 +203,6 @@ class Discrete(gym.spaces.Discrete, MineRLSpace):
     def __init__(self, *args, **kwargs):
         super(Discrete, self).__init__(*args, **kwargs)
         self.eye = np.eye(self.n, dtype=np.float32)
-        #self.shape = () #can't set attribute
 
     def no_op(self, batch_shape=()):
         if len(batch_shape) == 0:

--- a/minerl/interactor/__main__.py
+++ b/minerl/interactor/__main__.py
@@ -20,7 +20,9 @@ logger = logging.getLogger(__name__)
 
 def request_interactor(instance, ip):
     sock = get_socket(instance)
-    _MultiAgentEnv._TO_MOVE_hello(sock)
+    #_MultiAgentEnv._TO_MOVE_hello(sock)
+    comms.send_message(sock,
+        ("<MalmoEnv" + malmo_version + "/>").encode())
 
     comms.send_message(sock,
                        ("<Interact>" + ip + "</Interact>").encode())

--- a/minerl/interactor/__main__.py
+++ b/minerl/interactor/__main__.py
@@ -20,9 +20,8 @@ logger = logging.getLogger(__name__)
 
 def request_interactor(instance, ip):
     sock = get_socket(instance)
-    #_MultiAgentEnv._TO_MOVE_hello(sock)
     comms.send_message(sock,
-        ("<MalmoEnv" + malmo_version + "/>").encode())
+                       ("<MalmoEnv" + malmo_version + "/>").encode())
 
     comms.send_message(sock,
                        ("<Interact>" + ip + "</Interact>").encode())


### PR DESCRIPTION
* Sleep 10 sec immediately after sending a message to avoid  "Invalid session id" on _multiagent.py
* Fixed socket to send hello messages on interactor.__main__.request_interactor


I tried to fix Interactive Mode which is broken in version 0.4

If you run env.make_interactive (), the socket times out after the following message is displayed:
"Could not authorize you against Realms server: Invalid session id"
This could be avoided by sleeved for a few seconds (8 seconds or more) after sending the message.

I didn't know the detailed mechanism to solve it.
Please let me know if there is a better solution.


Fixed the socket where the message of interactor.request_interactor is sent.
The following function refers to the instance instead of the socket as an argument, so it needs to be modified.
"_MultiAgentEnv._TO_MOVE_hello (sock)"


With the above, the error can be corrected and it can be confirmed that the player has joined the environment of the agent.
However, the Minecraft launcher freezes without displaying the game screen.

I tried to find a solution, but I couldn't figure it out with my help as a beginner.
If anyone knows the cause, would you please tell me?