### PR TITLE
Add pyglet to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ simple-term-menu
 bullet
 filelock
 pytest
+pyglet


### PR DESCRIPTION
Required for the viewer [code](https://github.com/minerllabs/minerl/search?q=pyglet). Otherwise it crashes when you call `env.render()`

```python3
import gym
import minerl


def main():

  env = gym.make('MineRLNavigateDense-v0')

  obs  = env.reset()
  done = False
  net_reward = 0

  while not done:
    action = env.action_space.noop()

    obs, reward, done, info = env.step(
        action)
    env.render()

if __name__ == "__main__":
  main()
```