### PR TITLE
v0.3.7 readthedocs fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+version: 2
+
+sphinx:
+    configuration: docs/source/conf.py
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,11 @@ def setup(build=True, installdir=malmo_dir):
     return minecraft_dir
 
 
-download()
+if os.environ.get("READTHEDOCS"):
+    # Don't build binaries (requires Java) on readthedocs.io server.
+    print("Skipping Java binaries download/install since READTHEDOCS is set.")
+else:
+    download()
 
 def package_files(directory):
     paths = []


### PR DESCRIPTION
Add .readthedocs.yml that uses pip install . instead of pip install -r requirements.txt.
Add READTHEDOCS toggle to avoid installing java dependence.