### PR TITLE
fix life status not reading from info problem

### DIFF
--- a/minerl/herobraine/hero/handlers/agent/observations/lifestats.py
+++ b/minerl/herobraine/hero/handlers/agent/observations/lifestats.py
@@ -40,7 +40,7 @@ class LifeStatsObservation(KeymapTranslationHandler):
     def __init__(self, hero_keys, univ_keys, space, default_if_missing=None):
         self.hero_keys = hero_keys
         self.univ_keys = univ_keys
-        super().__init__(hero_keys=hero_keys, univ_keys=['life_stats'] + univ_keys, space=space,
+        super().__init__(hero_keys=['life_stats'] + hero_keys, univ_keys=['life_stats'] + univ_keys, space=space,
                          default_if_missing=default_if_missing)
 
     def xml_template(self) -> str:

--- a/minerl/herobraine/hero/handlers/agent/observations/lifestats.py
+++ b/minerl/herobraine/hero/handlers/agent/observations/lifestats.py
@@ -40,11 +40,15 @@ class LifeStatsObservation(KeymapTranslationHandler):
     def __init__(self, hero_keys, univ_keys, space, default_if_missing=None):
         self.hero_keys = hero_keys
         self.univ_keys = univ_keys
-        super().__init__(hero_keys=['life_stats'] + hero_keys, univ_keys=['life_stats'] + univ_keys, space=space,
-                         default_if_missing=default_if_missing)
+        super().__init__(hero_keys=hero_keys, univ_keys=['life_stats'] + univ_keys,
+                         space=space, default_if_missing=default_if_missing)
 
     def xml_template(self) -> str:
         return str("""<ObservationFromFullStats/>""")
+
+    def from_hero(self, hero_dict):
+        hero_dict = hero_dict['life_stats']
+        return super().from_hero(hero_dict)
 
 
 class _IsAliveObservation(LifeStatsObservation):


### PR DESCRIPTION
I've tried the lifeStats observation, and found that it is actually not changing at all. I took a look at the code and found that the `'life_stats'` key is missing. The info provided by java side is like
```
{
  'life_stats': {
    'xx': xx,
    'xx': xx
  }
}
```
If we don't add `'life_stats'` before `hero_keys`, when we do `walk_dict`, it will directly call `info['xx']` but not `info['life_stats']['xx']`. Then it will return the `default_is_missing` value. 