### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
+++ b/minerl/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
@@ -847,7 +847,7 @@ public class ServerStateMachine extends StateMachine
             attribute.removeModifier(modifier_id);
             double toAdd = maxHealth - attribute.getAttributeValue();
             // Note: the last argument being 0 means that this is an addition modifier.
-            // See https://minecraft.gamepedia.com/Attribute#Modifiers
+            // See https://minecraft.wiki/w/Attribute#Modifiers
             attribute.applyModifier(new AttributeModifier(modifier_id, "Set Max Health", toAdd, 0));
         }
 

--- a/minerl/Malmo/Schemas/MissionHandlers.xsd
+++ b/minerl/Malmo/Schemas/MissionHandlers.xsd
@@ -207,7 +207,7 @@
 
                         If left blank, the world will be a normal survival world.
 
-                        Biome ID #'s can be found here: https://minecraft.gamepedia.com/Biome#Biome_IDs
+                        Biome ID #'s can be found here: https://minecraft.wiki/w/Biome#Biome_IDs
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>

--- a/minerl/herobraine/env_specs/basalt_specs.py
+++ b/minerl/herobraine/env_specs/basalt_specs.py
@@ -380,7 +380,7 @@ Finally, end the episode by setting the "ESC" action to 1.
 .. tip::
   You can find detailed information on which materials are used in each biome-specific
   village (plains, savannah, taiga, desert) here:
-  https://minecraft.fandom.com/wiki/Village/Structure/Blueprints
+  https://minecraft.wiki/w/Village/Structure/Blueprints
 """
     def __init__(self):
         super().__init__(

--- a/minerl/herobraine/hero/handlers/agent/observations/lifestats.py
+++ b/minerl/herobraine/hero/handlers/agent/observations/lifestats.py
@@ -90,7 +90,7 @@ class _ScoreObservation(LifeStatsObservation):
 class _FoodObservation(LifeStatsObservation):
     """
     Handles food_level observation representing the player's current hunger level, shown on the hunger bar. Its initial
-    value on world creation is 20 (full bar) - https://minecraft.gamepedia.com/Hunger#Mechanics
+    value on world creation is 20 (full bar) - https://minecraft.wiki/w/Hunger#Mechanics
     """
 
     def __init__(self):
@@ -103,7 +103,7 @@ class _SaturationObservation(LifeStatsObservation):
     """
     Returns the food saturation observation which determines how fast the hunger level depletes and is controlled by the
      kinds of food the player has eaten. Its maximum value always equals foodLevel's value and decreases with the hunger
-     level. Its initial value on world creation is 5. - https://minecraft.gamepedia.com/Hunger#Mechanics
+     level. Its initial value on world creation is 5. - https://minecraft.wiki/w/Hunger#Mechanics
     """
 
     def __init__(self):
@@ -115,7 +115,7 @@ class _SaturationObservation(LifeStatsObservation):
 class _XPObservation(LifeStatsObservation):
     """
     Handles observation of experience points 1395 experience corresponds with level 30
-    - see https://minecraft.gamepedia.com/Experience for more details
+    - see https://minecraft.wiki/w/Experience for more details
     """
 
     def __init__(self):


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.