### PR TITLE
Add support for temporary instances

### DIFF
--- a/minerl/env/malmo.py
+++ b/minerl/env/malmo.py
@@ -381,7 +381,7 @@ class MinecraftInstance(object):
             if not port:
                 port = InstanceManager._get_valid_port()
 
-            if os.environ.get("MINERL_TMP_INSTANCES", 0):
+            if os.environ.get("MINERL_TMP_INSTANCES", "false").lower() in ("true", "1"):
                 # Copies built .jar and makes logs + save files write to a temporary
                 # directory to avoid issues e.g. when running on slurm.
                 self.instance_tempdir = tempfile.TemporaryDirectory()

--- a/minerl/env/malmo.py
+++ b/minerl/env/malmo.py
@@ -350,6 +350,7 @@ class MinecraftInstance(object):
         self.existing = existing
         self.minecraft_dir = None
         self.instance_dir = None
+        self.instance_tempdir = None
         self._status_dir = status_dir
         self.owner = None
         self._max_mem = max_mem
@@ -380,17 +381,40 @@ class MinecraftInstance(object):
             if not port:
                 port = InstanceManager._get_valid_port()
 
-            # self.instance_dir = tempfile.mkdtemp()
-            # self.minecraft_dir = os.path.join(self.instance_dir, 'Minecraft')
-            # shutil.copytree(os.path.join(InstanceManager.MINECRAFT_DIR), self.minecraft_dir,
-            #                 ignore=shutil.ignore_patterns('cache.properties.lock'))
-            # shutil.copytree(os.path.join(InstanceManager.SCHEMAS_DIR), os.path.join(self.instance_dir, 'Malmo', 'Schemas'))
-            self.minecraft_dir = InstanceManager.MINECRAFT_DIR
-            self.instance_dir = os.path.join(InstanceManager.MINECRAFT_DIR, '..')
+            if os.environ.get("MINERL_TMP_INSTANCES", 0):
+                # Copies built .jar and makes logs + save files write to a temporary
+                # directory to avoid issues e.g. when running on slurm.
+                self.instance_tempdir = tempfile.TemporaryDirectory()
+                self.instance_dir = self.instance_tempdir.name
+
+                self.minecraft_dir = os.path.join(self.instance_dir, "MCP-Reborn")
+                os.makedirs(os.path.join(self.minecraft_dir, "build"), exist_ok=True)
+                shutil.copytree(
+                    os.path.join(InstanceManager.MINECRAFT_DIR, "build", "libs"),
+                    os.path.join(self.minecraft_dir, "build", "libs"),
+                    ignore=shutil.ignore_patterns("cache.properties.lock")
+                )
+                shutil.copy2(
+                    os.path.join(InstanceManager.MINECRAFT_DIR, "launchClient.sh"),
+                    os.path.join(self.minecraft_dir, "launchClient.sh")
+                )
+                shutil.copy2(
+                    os.path.join(InstanceManager.MINECRAFT_DIR, "launchClient.bat"),
+                    os.path.join(self.minecraft_dir, "launchClient.bat")
+                )
+                shutil.copytree(
+                    os.path.join(InstanceManager.SCHEMAS_DIR),
+                    os.path.join(self.instance_dir, "Malmo", "Schemas"),
+                )
+            else:
+                # By default, runs with existing jar and puts logs + save files in
+                # minerl/MCP-Reborn.
+                self.minecraft_dir = InstanceManager.MINECRAFT_DIR
+                self.instance_dir = os.path.join(InstanceManager.MINECRAFT_DIR, '..')
 
             # 0. Get PID of launcher.
             parent_pid = os.getpid()
-            # 1. Launch minecraft process and 
+            # 1. Launch minecraft process
             self.minecraft_process = self._launch_minecraft(
                 port,
                 InstanceManager.headless,
@@ -647,7 +671,9 @@ class MinecraftInstance(object):
             if self in InstanceManager._instance_pool:
                 InstanceManager._instance_pool.remove(self)
                 self.release_lock()
-        pass
+
+            if self.instance_tempdir is not None:
+                self.instance_tempdir.cleanup()
 
     def __repr__(self):
         return ("Malmo[{}:{}, proc={}, addr={}:{}, locked={}]".format(


### PR DESCRIPTION
MineRL can run into issues (crashing, save file corruption) if multiple processes write to the same location in MCP-Reborn, e.g. if running on Slurm over NFS.

This makes it so that if the environment variable MINERL_TMP_INSTANCES is configured, the built JAR file, launchClient.bash, launchClient.sh, and Malmo/Schemas gets copied to a temporary directory for each instance.

Example:
```
xvfb-run -a python tests/basic_test.py
ls minerl/MCP-Reborn/saves  # expected: 1 new save file

MINERL_TMP_INSTANCES=1 xvfb-run -a python tests/basic_test.py  # logs show name of the tmp dir
find /tmp -maxdepth 1 -cmin 60  # expected: tmp dir was cleaned up
ls minerl/MCP-Reborn/saves  # expected: no new saves
```

Note: if MineRL crashes the temporary directory won't be cleaned up, but (depending on OS) it'll at least get cleaned up on reboot. Alternatively, calling env.close() in a try: finally: block will ensure the tempdir is cleaned up.