### PR TITLE
UnicodeDecodeError: 'charmap' codec can't decode byte

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ from distutils.command.build import build
 from setuptools.dist import Distribution
 import shutil
 
-with open("README.md", "r", encoding="utf8") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     markdown = fh.read()
-with open("requirements.txt", "r", encoding="utf8") as fh:
+with open("requirements.txt", "r", encoding="utf-8") as fh:
     requirements = fh.read()
 
 MALMO_BRANCH = "minerl"

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ from distutils.command.build import build
 from setuptools.dist import Distribution
 import shutil
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     markdown = fh.read()
-with open("requirements.txt", "r") as fh:
+with open("requirements.txt", "r", encoding="utf8") as fh:
     requirements = fh.read()
 
 MALMO_BRANCH = "minerl"


### PR DESCRIPTION
I think the original code has some problems running on Windows because it doesn't specify encoding in the following lines.
```
with open("README.md", "r") as fh:
    markdown = fh.read()
with open("requirements.txt", "r") as fh:
    requirements = fh.read()
```
which would cause the following error in Windows:
` UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1458: character maps to <undefined>`
I made a change to fix it, and everything went well.