### PR TITLE
Fix env.reset() hang on Windows native (MainWindow.resize deadlock)

### DIFF
--- a/scripts/patch_mcp.sh
+++ b/scripts/patch_mcp.sh
@@ -4,6 +4,11 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd ${DIR}/../minerl/MCP-Reborn
 patch -s -p 1 -i ${DIR}/mcp_patch.diff
+# Fixes a resize() hang on Windows native (MainWindow.resize() never pumps the
+# window's message queue, so WM_SIZE is never delivered) plus a follow-on issue
+# where decorated windows can't be resized below Windows' minimum caption width.
+# See: https://github.com/minerllabs/minerl/issues/814
+patch -s -p 1 -i ${DIR}/windows_resize_fix.diff
 # Copy cursors over
 cp -r ${DIR}/cursors ./src/main/resources
 # Ensure all scripts are runnable

--- a/scripts/windows_resize_fix.diff
+++ b/scripts/windows_resize_fix.diff
@@ -1,0 +1,18 @@
+--- a/src/main/java/net/minecraft/client/MainWindow.java
++++ b/src/main/java/net/minecraft/client/MainWindow.java
+@@ -90,2 +90,4 @@
+       GLFW.glfwWindowHint(GLFW.GLFW_VISIBLE, GLFW.GLFW_FALSE);
++      // decorated windows can't be resized below Windows' minimum caption width
++      GLFW.glfwWindowHint(GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
+       this.handle = GLFW.glfwCreateWindow(this.width, this.height, titleIn, this.fullscreen && monitor != null ? monitor.getMonitorPointer() : 0L, 0L);
+@@ -294,4 +296,8 @@
+       // frameBuffer / width == framebufferHeight / height
+-      while ((fbWidth == framebufferWidth && fbWidth == framebufferHeight) ||
+-              (framebufferHeight * newWidth != framebufferWidth * newHeight)) {
++      // glfwWaitEventsTimeout pumps the message queue so WM_SIZE is actually delivered on Windows;
++      // remainingTries is a safety net in case the framebuffer still doesn't converge
++      int remainingTries = 50;
++      while (((fbWidth == framebufferWidth && fbWidth == framebufferHeight) ||
++              (framebufferHeight * newWidth != framebufferWidth * newHeight)) && remainingTries-- > 0) {
++         GLFW.glfwWaitEventsTimeout(0.1);
+          updateFramebufferSize();


### PR DESCRIPTION
Fixes #814.

While setting up MineRL on Windows 11 native (not WSL), I found that `env.reset()` consistently hung until `socket.timeout`.

I used Claude Code as a debugging assistant, but verified every finding locally before drawing conclusions. A native stack trace (`cdb.exe`) showed the render thread blocked in `USER32!GetClientRect`, called from GLFW's `glfwGetFramebufferSize()`.

The root cause is that `MainWindow.resize()` waits for the framebuffer size to converge after `glfwSetWindowSize()`, but never pumps the window message queue. On Windows, `glfwSetWindowSize()` is asynchronous: the framebuffer is only updated after `WM_SIZE` is processed. Since the wait loop runs on the same thread that owns the window, `WM_SIZE` is never delivered and the loop spins forever.

While fixing this, I found a second Windows-specific issue. After adding a message pump, resizing could still stop at widths such as `176x64` when requesting `64x64`. This is caused by Windows' minimum caption-bar width for decorated windows. Because this GLFW window is already hidden (`GLFW_VISIBLE = false`), making it undecorated removes the constraint without changing visible behavior.

This patch therefore:

- pumps pending window events with `glfwWaitEventsTimeout(0.1)` while waiting for the framebuffer size to update;
- adds a bounded retry count to avoid waiting forever;
- creates the hidden GLFW window with `GLFW_DECORATED = false`.

I verified the patch against a fresh decompile and confirmed that `env.reset()` / `env.step()` complete successfully and `obs['pov']` is returned at the requested resolution.

Tested on:

- Windows 11 (native, not WSL)
- NVIDIA RTX 5060 Ti (driver 32.0.16.1062)
- JDK 8 Temurin
- Python 3.9.13
- MineRL v1.0.2

Full root-cause analysis is available in #814.